### PR TITLE
chore: relax protobuf and update opentelemetry deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ authors = [
 requires-python = ">=3.10,<3.13"
 dependencies = [
     "betterproto[compiler]==2.0.0b6",
-    "protobuf>=3.19,<4",              # Restrict version to maintain compatibility with opentelemetry
+    "protobuf>=3.19,<5",
     "grpclib>=0.4.3rc,<0.5",          # pre-release to support python 3.10
     "networkx>=2.6.3,<3",
     "graphviz>=0.20,<0.21",
@@ -32,8 +32,8 @@ tkrs = 'tierkreis.cli:cli'
 docker = ["docker>=5,<6"]
 
 telemetry = [
-    "opentelemetry-sdk>=1.5.0,<2",
-    "opentelemetry-exporter-otlp>=1.5.0,<2",
+    "opentelemetry-sdk>=1.15.0,<2",
+    "opentelemetry-exporter-otlp>=1.15.0,<2",
 ]
 
 commontypes = ["pytket>=1.0"]


### PR DESCRIPTION
This should work, as far as I can tell. The tests pass and opentelemetry now supports protobuf 4, as per:
- [Opentelemetry Changelog 1.15](https://github.com/open-telemetry/opentelemetry-python/blob/main/CHANGELOG.md#version-1150036b0-2022-12-09)
- [Protobuf 4.x support issue](https://github.com/open-telemetry/opentelemetry-python/issues/2880).

It would be super useful to have protobuf 4 support! Thanks already 😊 