### PR TITLE
fix: update map for arbitrary keys in vis

### DIFF
--- a/tierkreis_visualization/static/_types.js
+++ b/tierkreis_visualization/static/_types.js
@@ -1,21 +1,21 @@
 /**
  * @typedef {Object} PyNode
- * @property {number} id - The node ID.
+ * @property {number | string} id - The node ID.
  * @property {"Not started" | "Started" | "Finished"} status  - The node name.
  * @property {string} function_name - The node label..
  */
 
 /**
  * @typedef {Object} PyEdge
- * @property {number} from_node - The edge name.
+ * @property {number | string} from_node - The edge name.
  * @property {string} from_port - The edge arrow
- * @property {number} to_node - The edge name.
+ * @property {number | string} to_node - The edge name.
  * @property {string} to_port - The edge label.
  */
 
 /**
  * @typedef {Object} JSNode
- * @property {number} id - The node ID.
+ * @property {number | string} id - The node ID.
  * @property {string} title - The node name.
  * @property {string} label - The node label..
  * @property {string} shape - Node shape.
@@ -26,8 +26,8 @@
 /**
  * @typedef {Object} JSEdge
  * @property {string} id - The edge ID.
- * @property {number} from - The edge name.
- * @property {number} to - The edge label..
+ * @property {number | string} from - The edge name.
+ * @property {number | string} to - The edge label..
  * @property {string} title - The edge name.
  * @property {string} label - Node shape.
  * @property {string} arrows - The edge arrow
@@ -44,5 +44,3 @@
  * @property {PyNode[]} nodes - The edge ID.
  * @property {PyEdge[]} edges - The edge name.
  */
-
-

--- a/tierkreis_visualization/tierkreis_visualization/data/map.py
+++ b/tierkreis_visualization/tierkreis_visualization/data/map.py
@@ -1,4 +1,3 @@
-from math import ceil, sqrt
 from pydantic import BaseModel
 from tierkreis.controller.data.location import Loc
 from tierkreis.controller.storage.protocol import ControllerStorage

--- a/tierkreis_visualization/tierkreis_visualization/data/map.py
+++ b/tierkreis_visualization/tierkreis_visualization/data/map.py
@@ -2,7 +2,8 @@ from math import ceil, sqrt
 from pydantic import BaseModel
 from tierkreis.controller.data.location import Loc
 from tierkreis.controller.storage.protocol import ControllerStorage
-
+from tierkreis.controller.data.graph import Map
+from tierkreis.exceptions import TierkreisError
 from tierkreis_visualization.data.models import PyEdge, PyNode
 
 
@@ -11,33 +12,17 @@ class MapNodeData(BaseModel):
     edges: list[PyEdge]
 
 
-def get_map_node(storage: ControllerStorage, node_location: Loc) -> MapNodeData:
-    i = 0
+def get_map_node(storage: ControllerStorage, loc: Loc, map: Map) -> MapNodeData:
+    parent = loc.parent()
+    if parent is None:
+        raise TierkreisError("MAP node must have parent.")
+
+    map_eles = storage.read_output_ports(parent.N(map.input_idx))
     nodes: list[PyNode] = []
-    while True:
-        loc = node_location.M(i)
-        if not storage.is_node_started(loc):
-            break
-
-        node = PyNode(id=i, status="Started", function_name=f"M{i}")
-        nodes.append(node)
-        i += 1
-
-        if storage.is_node_finished(loc):
+    for ele in map_eles:
+        node = PyNode(id=ele, status="Started", function_name=ele)
+        if storage.is_node_finished(loc.M(ele)):
             node.status = "Finished"
-            continue
+        nodes.append(node)
 
-    edges: list[PyEdge] = []
-    N = ceil(sqrt(i))
-    for col in range(N):
-        for row in range(N - 1):
-            edges.append(
-                PyEdge(
-                    from_node=row + N * col,
-                    to_node=row + N * col + 1,
-                    from_port=str(row),
-                    to_port=str(col),
-                )
-            )
-
-    return MapNodeData(nodes=nodes, edges=edges)
+    return MapNodeData(nodes=nodes, edges=[])

--- a/tierkreis_visualization/tierkreis_visualization/data/models.py
+++ b/tierkreis_visualization/tierkreis_visualization/data/models.py
@@ -1,12 +1,12 @@
 from typing import Literal
 from pydantic import BaseModel
-
+from tierkreis.controller.data.graph import PortID
 
 NodeStatus = Literal["Not started", "Started", "Finished"]
 
 
 class PyNode(BaseModel):
-    id: int
+    id: int | PortID
     status: NodeStatus
     function_name: str
 

--- a/tierkreis_visualization/tierkreis_visualization/routers/workflows.py
+++ b/tierkreis_visualization/tierkreis_visualization/routers/workflows.py
@@ -40,6 +40,7 @@ def get_node_data(workflow_id: UUID, node_location: Loc) -> dict[str, Any]:
     storage = get_storage(workflow_id)
 
     definition = storage.read_worker_call_args(node_location)
+    node = storage.read_node_def(node_location)
     function_name = definition.function_name
 
     if function_name == "eval":
@@ -55,7 +56,7 @@ def get_node_data(workflow_id: UUID, node_location: Loc) -> dict[str, Any]:
         ctx = PyGraph(nodes=data.nodes, edges=data.edges).model_dump(by_alias=True)
 
     elif function_name == "map":
-        data = get_map_node(storage, node_location)
+        data = get_map_node(storage, node_location, node)
         name = "map.jinja"
         ctx = PyGraph(nodes=data.nodes, edges=data.edges).model_dump(by_alias=True)
 


### PR DESCRIPTION
Note that if we move away from vis js for map nodes then we can restrict the 'node_id' back to a `number`.