### PR TITLE
Use recursion to process the non-hierarchical graphs also

### DIFF
--- a/python/tests/controller/test_graphdata.py
+++ b/python/tests/controller/test_graphdata.py
@@ -1,0 +1,11 @@
+import pytest
+from tierkreis.controller.data.graph import Const, GraphData, Output
+from tierkreis.exceptions import TierkreisError
+from tierkreis.labels import Labels
+
+
+def test_only_one_output():
+    with pytest.raises(TierkreisError):
+        g = GraphData()
+        g.add(Output({"one": g.add(Const(1))(Labels.VALUE)}))
+        g.add(Output({"two": g.add(Const(2))(Labels.VALUE)}))

--- a/python/tierkreis/controller/__init__.py
+++ b/python/tierkreis/controller/__init__.py
@@ -31,7 +31,6 @@ def run_graph(
     inputs: dict[PortID, ValueRef] = {
         k: (-1, k) for k, _ in graph_inputs.items() if k != "body"
     }
-    storage.mark_node_finished(root_loc.N(-1))
     node_run_data = NodeRunData(Loc(), Eval((-1, "body"), inputs), [])
     start(storage, executor, node_run_data)
     resume_graph(storage, executor, n_iterations, polling_interval_seconds)

--- a/python/tierkreis/controller/__init__.py
+++ b/python/tierkreis/controller/__init__.py
@@ -1,3 +1,5 @@
+import json
+import logging
 from time import sleep
 
 from tierkreis.controller.data.graph import Eval, GraphData, ValueRef
@@ -9,6 +11,7 @@ from tierkreis.controller.storage.walk import walk_node
 from tierkreis.controller.data.graph import PortID
 
 root_loc = Loc("")
+logger = logging.getLogger(__name__)
 
 
 def run_graph(
@@ -26,8 +29,9 @@ def run_graph(
     storage.write_output(root_loc.N(-1), "body", g.model_dump_json().encode())
 
     inputs: dict[PortID, ValueRef] = {
-        k: (-1, k) for k, v in graph_inputs.items() if k != "body"
+        k: (-1, k) for k, _ in graph_inputs.items() if k != "body"
     }
+    storage.mark_node_finished(root_loc.N(-1))
     node_run_data = NodeRunData(Loc(), Eval((-1, "body"), inputs), [])
     start(storage, executor, node_run_data)
     resume_graph(storage, executor, n_iterations, polling_interval_seconds)
@@ -39,8 +43,11 @@ def resume_graph(
     n_iterations: int = 10000,
     polling_interval_seconds: float = 0.01,
 ) -> None:
-    for i in range(n_iterations):
-        walk_results = walk_node(storage, Loc())
+    message = storage.read_output(Loc().N(-1), "body")
+    graph = GraphData(**json.loads(message))
+
+    for _ in range(n_iterations):
+        walk_results = walk_node(storage, Loc(), graph.output_idx(), graph)
         if walk_results.errored != []:
             print("Graph finished with errors.")
             break

--- a/python/tierkreis/controller/data/graph.py
+++ b/python/tierkreis/controller/data/graph.py
@@ -79,6 +79,11 @@ class GraphData(BaseModel):
 
         match node.type:
             case "output":
+                if self.graph_output_idx is not None:
+                    raise TierkreisError(
+                        f"Graph already has output at {self.graph_output_idx}"
+                    )
+
                 self.graph_output_idx = idx
             case "const" | "eval" | "function" | "input" | "loop" | "map":
                 pass

--- a/python/tierkreis/controller/data/graph.py
+++ b/python/tierkreis/controller/data/graph.py
@@ -81,7 +81,7 @@ class GraphData(BaseModel):
             case "output":
                 if self.graph_output_idx is not None:
                     raise TierkreisError(
-                        f"Graph already has output at {self.graph_output_idx}"
+                        f"Graph already has output at index {self.graph_output_idx}"
                     )
 
                 self.graph_output_idx = idx

--- a/python/tierkreis/controller/data/graph.py
+++ b/python/tierkreis/controller/data/graph.py
@@ -1,7 +1,8 @@
 from dataclasses import dataclass, field
-from typing import Any, Callable, Literal
+from typing import Any, Callable, Literal, assert_never
 
 from pydantic import BaseModel, RootModel
+from tierkreis.exceptions import TierkreisError
 
 Jsonable = Any
 PortID = str
@@ -69,13 +70,33 @@ NodeDefModel = RootModel[NodeDef]
 class GraphData(BaseModel):
     nodes: list[NodeDef] = []
     outputs: list[set[PortID]] = []
+    graph_output_idx: NodeIndex | None = None
 
     def add(self, node: NodeDef) -> Callable[[PortID], ValueRef]:
         idx = len(self.nodes)
         self.nodes.append(node)
         self.outputs.append(set())
 
+        match node.type:
+            case "output":
+                self.graph_output_idx = idx
+            case "const" | "eval" | "function" | "input" | "loop" | "map":
+                pass
+            case _:
+                assert_never(node)
+
         for i, port in node.inputs.values():
             self.outputs[i].add(port)
 
         return lambda k: (idx, k)
+
+    def output_idx(self) -> NodeIndex:
+        idx = self.graph_output_idx
+        if idx is None:
+            raise TierkreisError("Graph has no output index.")
+
+        node = self.nodes[idx]
+        if node.type != "output":
+            raise TierkreisError(f"Expected output node at {idx} found {node}")
+
+        return idx

--- a/python/tierkreis/controller/data/location.py
+++ b/python/tierkreis/controller/data/location.py
@@ -52,10 +52,10 @@ class Loc(str):
         return Loc(loc)
 
     def parent(self) -> "Loc | None":
+        steps = self.steps()
         if not self.steps():
             return None
 
-        steps = self.steps()
         last_step = steps.pop()
         match last_step:
             case "-":

--- a/python/tierkreis/controller/data/location.py
+++ b/python/tierkreis/controller/data/location.py
@@ -52,7 +52,7 @@ class Loc(str):
         return Loc(loc)
 
     def parent(self) -> "Loc | None":
-        if not self.steps:
+        if not self.steps():
             return None
 
         steps = self.steps()
@@ -70,8 +70,13 @@ class Loc(str):
                 assert_never(last_step)
 
     def steps(self) -> list[NodeStep]:
+        if self == "":
+            return []
+
         steps: list[NodeStep] = []
         for step_str in self.split("."):
+            if step_str == "":
+                continue
             match step_str[0], step_str[1:]:
                 case ("-", _):
                     steps.append("-")
@@ -85,6 +90,12 @@ class Loc(str):
                     raise TierkreisError(f"Invalid Loc: {self}")
 
         return steps
+
+    def peek(self) -> NodeStep | None:
+        steps = self.steps()
+        if not steps:
+            return None
+        return steps[-1]
 
 
 OutputLoc = tuple[Loc, PortID]

--- a/python/tierkreis/controller/data/location.py
+++ b/python/tierkreis/controller/data/location.py
@@ -91,12 +91,6 @@ class Loc(str):
 
         return steps
 
-    def peek(self) -> NodeStep | None:
-        steps = self.steps()
-        if not steps:
-            return None
-        return steps[-1]
-
 
 OutputLoc = tuple[Loc, PortID]
 

--- a/python/tierkreis/controller/data/location.py
+++ b/python/tierkreis/controller/data/location.py
@@ -53,7 +53,7 @@ class Loc(str):
 
     def parent(self) -> "Loc | None":
         steps = self.steps()
-        if not self.steps():
+        if not steps:
             return None
 
         last_step = steps.pop()

--- a/python/tierkreis/controller/data/location.py
+++ b/python/tierkreis/controller/data/location.py
@@ -75,8 +75,6 @@ class Loc(str):
 
         steps: list[NodeStep] = []
         for step_str in self.split("."):
-            if step_str == "":
-                continue
             match step_str[0], step_str[1:]:
                 case ("-", _):
                     steps.append("-")

--- a/python/tierkreis/controller/start.py
+++ b/python/tierkreis/controller/start.py
@@ -24,8 +24,12 @@ def start_nodes(
     executor: ControllerExecutor,
     node_run_data: list[NodeRunData],
 ) -> None:
+    started_locs: set[Loc] = set()
     for node_run_datum in node_run_data:
+        if node_run_datum.node_location in started_locs:
+            continue
         start(storage, executor, node_run_datum)
+        started_locs.add(node_run_datum.node_location)
 
 
 def run_builtin(def_path: Path, logs_path: Path) -> None:

--- a/python/tierkreis/controller/storage/adjacency.py
+++ b/python/tierkreis/controller/storage/adjacency.py
@@ -1,6 +1,8 @@
 from typing import assert_never
 
 from tierkreis.controller.data.graph import NodeDef, PortID, ValueRef
+from tierkreis.controller.data.location import Loc
+from tierkreis.controller.storage.protocol import ControllerStorage
 
 
 def in_edges(node: NodeDef) -> dict[PortID, ValueRef]:
@@ -20,3 +22,11 @@ def in_edges(node: NodeDef) -> dict[PortID, ValueRef]:
             assert_never(node)
 
     return parents
+
+
+def unfinished_inputs(
+    storage: ControllerStorage, loc: Loc, node: NodeDef
+) -> list[ValueRef]:
+    return [
+        x for x in in_edges(node).values() if not storage.is_node_finished(loc.N(x[0]))
+    ]

--- a/python/tierkreis/controller/storage/walk.py
+++ b/python/tierkreis/controller/storage/walk.py
@@ -4,11 +4,18 @@ from logging import getLogger
 from typing import assert_never
 
 from tierkreis.controller.consts import BODY_PORT
-from tierkreis.controller.data.graph import Eval, GraphData, Loop, Map
+from tierkreis.controller.data.graph import (
+    Eval,
+    GraphData,
+    Loop,
+    Map,
+    NodeDef,
+    NodeIndex,
+)
 from tierkreis.controller.data.location import Loc, NodeRunData
-from tierkreis.controller.storage.adjacency import in_edges
+from tierkreis.controller.storage.adjacency import unfinished_inputs
 from tierkreis.controller.storage.protocol import ControllerStorage
-from tierkreis.exceptions import TierkreisError
+from tierkreis.labels import Labels
 
 logger = getLogger(__name__)
 
@@ -25,77 +32,85 @@ class WalkResult:
         self.errored.extend(walk_result.errored)
 
 
-def walk_node(storage: ControllerStorage, loc: Loc) -> WalkResult:
-    """Should only be called when a node has started and has not finished."""
+def add_unfinished_inputs(
+    result: WalkResult,
+    storage: ControllerStorage,
+    parent: Loc,
+    node: NodeDef,
+    graph: GraphData,
+) -> int:
+    unfinished = unfinished_inputs(storage, parent, node)
+    [result.extend(walk_node(storage, parent, x[0], graph)) for x in unfinished]
+    return len(unfinished)
 
-    logger.debug(f"\n\nRESUME {loc}")
+
+def walk_node(
+    storage: ControllerStorage, parent: Loc, idx: NodeIndex, graph: GraphData
+) -> WalkResult:
+    """Should only be called when a node has not finished."""
+    loc = parent.N(idx)
     if storage.node_has_error(loc):
         logger.error(f"Node {loc} has encountered an error:")
         logger.error(f"\n\n{storage.read_errors(loc)}\n\n")
         return WalkResult([], [], [loc])
-    node = storage.read_node_def(loc)
+
+    node = graph.nodes[idx]
+    storage.write_node_def(loc, node)
+
+    result = WalkResult([], [])
+    if add_unfinished_inputs(result, storage, parent, node, graph):
+        return result
+
+    if not storage.is_node_started(loc):
+        node_run_data = NodeRunData(loc, node, list(graph.outputs[idx]))
+        return WalkResult([node_run_data], [])
 
     match node.type:
         case "eval":
-            return walk_eval(storage, loc)
+            message = storage.read_output(parent.N(node.graph[0]), node.graph[1])
+            g = GraphData(**json.loads(message))
+            result.extend(walk_node(storage, loc, g.output_idx(), g))
+
+        case "output":
+            node_run_data = NodeRunData(loc, node, [])
+            return WalkResult([node_run_data], [])
+
+        case "const":
+            node_run_data = NodeRunData(loc, node, [Labels.VALUE])
+            return WalkResult([node_run_data], [])
 
         case "loop":
-            return walk_loop(storage, loc, node)
+            return walk_loop(storage, parent, idx, node)
 
         case "map":
-            return walk_map(storage, loc, node)
+            return walk_map(storage, parent, idx, node)
 
-        case "const" | "function" | "input" | "output":
-            logger.debug(f"{loc} ({node.type}) already started")
-            return WalkResult([], [loc])
+        case "function":
+            pass
 
+        case "input":
+            pass
         case _:
             assert_never(node)
 
-
-def walk_eval(storage: ControllerStorage, loc: Loc) -> WalkResult:
-    logger.debug("walk_eval")
-    walk_result = WalkResult([], [])
-    message = storage.read_output(loc.N(-1), BODY_PORT)
-    graph = GraphData(**json.loads(message))
-
-    logger.debug(len(graph.nodes))
-    for i, node in enumerate(graph.nodes):
-        new_location = loc.N(i)
-        logger.debug(f"new_location: {new_location}")
-
-        if storage.is_node_finished(new_location):
-            logger.debug(f"{new_location} is finished")
-            continue
-
-        if storage.is_node_started(new_location):
-            logger.debug(f"{new_location} is started")
-            walk_result.extend(walk_node(storage, new_location))
-            continue
-
-        parents = in_edges(node)
-        if all(storage.is_node_finished(loc.N(i)) for (i, _) in parents.values()):
-            logger.debug(f"{new_location} is_ready_to_start")
-            outputs = graph.outputs[i]
-            node_run_data = NodeRunData(new_location, node, list(outputs))
-            walk_result.inputs_ready.append(node_run_data)
-            continue
-
-        logger.debug(f"node not ready to start {new_location}")
-
-    return walk_result
+    return result
 
 
-def walk_loop(storage: ControllerStorage, loc: Loc, loop: Loop) -> WalkResult:
+def walk_loop(
+    storage: ControllerStorage, parent: Loc, idx: NodeIndex, loop: Loop
+) -> WalkResult:
+    loc = parent.N(idx)
+
     acc_port = loop.acc_port
     i = 0
     while storage.is_node_started(loc.L(i + 1)):
         i += 1
     new_location = loc.L(i)
-    logger.debug(f"found latest iteration of loop: {new_location}")
 
     if not storage.is_node_finished(new_location):
-        return walk_node(storage, new_location)
+        message = storage.read_output(loc.N(-1), BODY_PORT)
+        g = GraphData(**json.loads(message))
+        return walk_node(storage, new_location, g.output_idx(), g)
 
     # Latest iteration is finished. Do we BREAK or CONTINUE?
     should_continue = json.loads(storage.read_output(new_location, loop.continue_port))
@@ -104,28 +119,30 @@ def walk_loop(storage: ControllerStorage, loc: Loc, loop: Loop) -> WalkResult:
         storage.mark_node_finished(loc)
         return WalkResult([], [])
 
-    # Include old inputs. The .acc_port is the only one that can change.
+    # Include old inputs. The acc_port is the only one that can change.
     ins = {k: (-1, k) for k in loop.inputs.keys() if k != acc_port}
     storage.link_outputs(loc.L(i + 1).N(-1), acc_port, new_location, acc_port)
-    node_run_data = NodeRunData(loc.L(i + 1), Eval((-1, "body"), ins), [acc_port])
+    node_run_data = NodeRunData(loc.L(i + 1), Eval((-1, BODY_PORT), ins), [acc_port])
     return WalkResult([node_run_data], [])
 
 
-def walk_map(storage: ControllerStorage, loc: Loc, map: Map) -> WalkResult:
-    walk_result = WalkResult([], [])
-    parent = loc.parent()
-    if parent is None:
-        raise TierkreisError("MAP node must have parent.")
+def walk_map(
+    storage: ControllerStorage, parent: Loc, idx: NodeIndex, map: Map
+) -> WalkResult:
+    loc = parent.N(idx)
+    result = WalkResult([], [])
 
     map_eles = storage.read_output_ports(parent.N(map.input_idx))
     unfinished = [p for p in map_eles if not storage.is_node_finished(loc.M(p))]
-    [walk_result.extend(walk_node(storage, loc.M(p))) for p in unfinished]
+    message = storage.read_output(loc.N(-1), BODY_PORT)
+    g = GraphData(**json.loads(message))
+    [result.extend(walk_node(storage, loc.M(p), g.output_idx(), g)) for p in unfinished]
 
     if len(unfinished) > 0:
-        return walk_result
+        return result
 
     for j in map_eles:
         storage.link_outputs(loc, j, loc.M(j), map.out_port)
         storage.mark_node_finished(loc)
 
-    return walk_result
+    return result


### PR DESCRIPTION
Happy to let https://github.com/CQCL/tierkreis/pull/49 and https://github.com/CQCL/tierkreis/pull/50 go in first.

Resume a node by recursively resuming its inputs. In particular an eval node is resumed by resuming its output node. This aligns with the interpretation of the graph as an operad or algebraic theory, although the code does not explicitly define such an algebraic structure.

* Change initial graph run/resume to read the graph from storage and call `walk_node` on the output node.
* In graph construction, keep track of which node is the output node.
* To account for shared references add code to `start` so that it does not start a node twice. (On subsequent ticks the controller will realise the graph has already started and not try to start.)
* Change `walk_node` to recursively process a nodes based on the inputs of other nodes.