### PR TITLE
feat: Allow multiple acc_ports for LOOP

### DIFF
--- a/examples/hamiltonian/hamiltonian_graph.py
+++ b/examples/hamiltonian/hamiltonian_graph.py
@@ -140,14 +140,7 @@ def _fold_graph() -> GraphData:
 
     helper = g.add(Const(_fold_graph_outer()))("value")
     # TODO: include the computation inside the fold
-    loop = g.add(
-        Loop(
-            helper,
-            {"func": func, "accum": accum},
-            "should_continue",
-            "accum",
-        )
-    )
+    loop = g.add(Loop(helper, {"func": func, "accum": accum}, "should_continue"))
 
     final_accum = g.add(Func("builtins.untuple", {"value": loop("accum")}))
 

--- a/examples/hamiltonian/hamiltonian_graph.py
+++ b/examples/hamiltonian/hamiltonian_graph.py
@@ -116,15 +116,7 @@ def _fold_graph_outer() -> GraphData:
     )
 
     next_accum = g.add(IfElse(non_empty, if_true, accum))("value")
-    g.add(
-        Output(
-            {
-                "func": func,
-                "accum": next_accum,
-                "should_continue": non_empty,
-            },
-        )
-    )
+    g.add(Output({"accum": next_accum, "should_continue": non_empty}))
     return g
 
 

--- a/tierkreis/tests/controller/loop_graphdata.py
+++ b/tierkreis/tests/controller/loop_graphdata.py
@@ -45,7 +45,10 @@ def loop_multiple_acc() -> GraphData:
 
     loop = g.add(
         Loop(
-            body_const, {"acc": acc, "acc2": acc2, "acc3": acc3}, "should_continue", []
+            body_const,
+            {"acc": acc, "acc2": acc2, "acc3": acc3},
+            "should_continue",
+            "acc",
         )
     )
 

--- a/tierkreis/tests/controller/loop_graphdata.py
+++ b/tierkreis/tests/controller/loop_graphdata.py
@@ -45,10 +45,7 @@ def loop_multiple_acc() -> GraphData:
 
     loop = g.add(
         Loop(
-            body_const,
-            {"acc": acc, "acc2": acc2, "acc3": acc3},
-            "should_continue",
-            ["acc", "acc2", "acc3"],
+            body_const, {"acc": acc, "acc2": acc2, "acc3": acc3}, "should_continue", []
         )
     )
 

--- a/tierkreis/tests/controller/loop_graphdata.py
+++ b/tierkreis/tests/controller/loop_graphdata.py
@@ -1,0 +1,57 @@
+from tierkreis.controller.data.graph import Const, Func, GraphData, Input, Loop, Output
+from tierkreis import Labels
+
+
+def _loop_body_multiple_acc() -> GraphData:
+    g = GraphData()
+
+    acc = g.add(Input("acc"))("acc")
+    acc2 = g.add(Input("acc2"))("acc2")
+    acc3 = g.add(Input("acc3"))("acc3")
+
+    one = g.add(Const(1))(Labels.VALUE)
+    two = g.add(Const(2))(Labels.VALUE)
+    three = g.add(Const(3))(Labels.VALUE)
+    five = g.add(Const(5))(Labels.VALUE)
+
+    should_continue = g.add(Func("builtins.igt", {"a": five, "b": acc}))(Labels.VALUE)
+
+    new_acc = g.add(Func("builtins.iadd", {"a": acc, "b": one}))(Labels.VALUE)
+    new_acc2 = g.add(Func("builtins.iadd", {"a": acc2, "b": two}))(Labels.VALUE)
+    new_acc3 = g.add(Func("builtins.iadd", {"a": acc3, "b": three}))(Labels.VALUE)
+
+    g.add(
+        Output(
+            {
+                "should_continue": should_continue,
+                "acc": new_acc,
+                "acc2": new_acc2,
+                "acc3": new_acc3,
+            }
+        )
+    )
+
+    return g
+
+
+def loop_multiple_acc() -> GraphData:
+    g = GraphData()
+
+    acc = g.add(Const(0))(Labels.VALUE)
+    acc2 = g.add(Const(0))(Labels.VALUE)
+    acc3 = g.add(Const(0))(Labels.VALUE)
+
+    body_const = g.add(Const(_loop_body_multiple_acc()))(Labels.VALUE)
+
+    loop = g.add(
+        Loop(
+            body_const,
+            {"acc": acc, "acc2": acc2, "acc3": acc3},
+            "should_continue",
+            ["acc", "acc2", "acc3"],
+        )
+    )
+
+    g.add(Output({"acc": loop("acc"), "acc2": loop("acc2"), "acc3": loop("acc3")}))
+
+    return g

--- a/tierkreis/tests/controller/loop_graphdata.py
+++ b/tierkreis/tests/controller/loop_graphdata.py
@@ -44,12 +44,7 @@ def loop_multiple_acc() -> GraphData:
     body_const = g.add(Const(_loop_body_multiple_acc()))(Labels.VALUE)
 
     loop = g.add(
-        Loop(
-            body_const,
-            {"acc": acc, "acc2": acc2, "acc3": acc3},
-            "should_continue",
-            "acc",
-        )
+        Loop(body_const, {"acc": acc, "acc2": acc2, "acc3": acc3}, "should_continue")
     )
 
     g.add(Output({"acc": loop("acc"), "acc2": loop("acc2"), "acc3": loop("acc3")}))

--- a/tierkreis/tests/controller/sample_graphdata.py
+++ b/tierkreis/tests/controller/sample_graphdata.py
@@ -49,7 +49,7 @@ def simple_loop() -> GraphData:
     g = GraphData()
     six = g.add(Const(6))(Labels.VALUE)
     g_const = g.add(Const(loop_body()))(Labels.VALUE)
-    loop = g.add(Loop(g_const, {"loop_acc": six}, "should_continue", "loop_acc"))
+    loop = g.add(Loop(g_const, {"loop_acc": six}, "should_continue"))
     g.add(Output({"simple_loop_output": loop("loop_acc")}))
     return g
 

--- a/tierkreis/tests/controller/test_resume.py
+++ b/tierkreis/tests/controller/test_resume.py
@@ -14,6 +14,7 @@ from tests.controller.sample_graphdata import (
     simple_loop,
     simple_map,
 )
+from tests.controller.loop_graphdata import loop_multiple_acc
 from tierkreis.controller import run_graph
 from tierkreis.controller.data.graph import GraphData
 from tierkreis.controller.data.location import Loc
@@ -31,6 +32,7 @@ params = [
     (simple_ifelse(), 2, "simple_ifelse", 7, {"pred": b"false"}),
     (factorial(), 24, "factorial", 8, {"n": b"4", "factorial": factorial_bytes}),
     (factorial(), 120, "factorial", 8, {"n": b"5", "factorial": factorial_bytes}),
+    (loop_multiple_acc(), {"acc": 6, "acc2": 12, "acc3": 18}, "multi_acc", 9, {}),
 ]
 ids = [
     "simple_eval",
@@ -42,6 +44,7 @@ ids = [
     "simple_ifelse_false",
     "factorial_4",
     "factorial_5",
+    "loop_multiple_acc",
 ]
 
 
@@ -57,5 +60,12 @@ def test_resume_eval(
     storage.clean_graph_files()
     run_graph(storage, executor, g, inputs)
 
-    c = json.loads(storage.read_output(Loc(), f"{name}_output"))
-    assert c == output
+    output_ports = g.nodes[g.output_idx()].inputs.keys()
+    actual_output = {}
+    for port in output_ports:
+        actual_output[port] = json.loads(storage.read_output(Loc(), port))
+
+    if f"{name}_output" in actual_output:
+        assert actual_output[f"{name}_output"] == output
+    else:
+        assert actual_output == output

--- a/tierkreis/tierkreis/controller/data/graph.py
+++ b/tierkreis/tierkreis/controller/data/graph.py
@@ -29,7 +29,7 @@ class Loop:
     body: ValueRef
     inputs: dict[PortID, ValueRef]
     continue_port: PortID  # The port that specified if the loop should continue.
-    acc_port: PortID  # The input and output that is modified by the loop.
+    acc_port: PortID | list[PortID]  # Ports the LOOP can modify.
     type: Literal["loop"] = field(default="loop")
 
 

--- a/tierkreis/tierkreis/controller/data/graph.py
+++ b/tierkreis/tierkreis/controller/data/graph.py
@@ -29,7 +29,7 @@ class Loop:
     body: ValueRef
     inputs: dict[PortID, ValueRef]
     continue_port: PortID  # The port that specified if the loop should continue.
-    acc_port: PortID | list[PortID]  # Ports the LOOP can modify.
+    acc_port: PortID  # Port the LOOP can modify.
     type: Literal["loop"] = field(default="loop")
 
 

--- a/tierkreis/tierkreis/controller/data/graph.py
+++ b/tierkreis/tierkreis/controller/data/graph.py
@@ -28,8 +28,7 @@ class Eval:
 class Loop:
     body: ValueRef
     inputs: dict[PortID, ValueRef]
-    continue_port: PortID  # The port that specified if the loop should continue.
-    acc_port: PortID  # Port the LOOP can modify.
+    continue_port: PortID  # The port that specifies if the loop should continue.
     type: Literal["loop"] = field(default="loop")
 
 


### PR DESCRIPTION
Related to https://github.com/CQCL/tierkreis/issues/61

Remove acc_port from the definition of loop node and thread all of the outputs of the loop body to the next iteration and ultimately the output of the loop node.

* Modify the tests and examples to use new definition.
* Create test. A graph with a loop body that has multiple outputs.
* When walking a loop node link all of the outputs into the correct place. (All inputs to the loop will remain accessible but not modified.)