### PR TITLE
fix: use NodeDef for is_node_started

### DIFF
--- a/tierkreis/tierkreis/controller/start.py
+++ b/tierkreis/tierkreis/controller/start.py
@@ -79,7 +79,6 @@ def start(
         raise TierkreisError(f"{node.type} node must have parent Loc.")
 
     ins = {k: (parent.N(idx), p) for k, (idx, p) in node.inputs.items()}
-    storage.write_worker_call_args(node_location, node.type, ins, output_list)
 
     logger.debug(f"start {node_location} {node} {ins} {output_list}")
     if node.type == "function":

--- a/tierkreis/tierkreis/controller/storage/filestorage.py
+++ b/tierkreis/tierkreis/controller/storage/filestorage.py
@@ -180,7 +180,7 @@ class ControllerFileStorage:
         return [x.name for x in dir_list if x.is_file()]
 
     def is_node_started(self, node_location: Loc) -> bool:
-        return Path(self._worker_call_args_path(node_location)).exists()
+        return Path(self._nodedef_path(node_location)).exists()
 
     def is_node_finished(self, node_location: Loc) -> bool:
         return self._done_path(node_location).exists()

--- a/tierkreis/tierkreis/controller/storage/walk.py
+++ b/tierkreis/tierkreis/controller/storage/walk.py
@@ -58,7 +58,6 @@ def walk_node(
 
     node = graph.nodes[idx]
     node_run_data = NodeRunData(loc, node, list(graph.node_outputs[idx]))
-    storage.write_node_def(loc, node)
 
     result = WalkResult([], [])
     if unfinished_results(result, storage, parent, node, graph):


### PR DESCRIPTION
Then we can avoid writing the worker call args for every node.