### PR TITLE
Draft simpler builder interface

### DIFF
--- a/examples/builder.py
+++ b/examples/builder.py
@@ -1,0 +1,30 @@
+from pathlib import Path
+from tierkreis.cli.run_workflow import run_workflow
+
+from tierkreis.controller.data.graph import GraphData
+from tierkreis import Labels
+
+
+def loop_body() -> GraphData:
+    g = GraphData()
+    g.input().const(1).const(10).func("builtins.iadd", {"a": 0, "b": 1}).func(
+        "builtins.igt", {"a": 2, "b": 3}
+    ).output({Labels.VALUE: -2, "should_continue": -1})
+    return g
+
+
+f = GraphData()
+f.const(6).loop(loop_body(), "should_continue", {Labels.VALUE: -1}).output()
+
+
+inputs = {}
+run_workflow(
+    f,
+    inputs,
+    name="exp",
+    run_id=55,  # Assign a fixed uuid for our workflow.
+    registry_path=Path(__file__).parent / "example_workers",
+    # Look for workers in the same directory.
+    use_uv_worker=True,
+    print_output=True,
+)

--- a/tierkreis/tierkreis/controller/data/graph.py
+++ b/tierkreis/tierkreis/controller/data/graph.py
@@ -1,7 +1,8 @@
 from dataclasses import dataclass, field
 from typing import Callable, Literal, assert_never
 
-from pydantic import BaseModel, RootModel
+from pydantic import BaseModel, RootModel, Field
+from tierkreis import Labels
 from tierkreis.controller.data.core import Jsonable
 from tierkreis.controller.data.core import PortID
 from tierkreis.controller.data.core import NodeIndex
@@ -90,6 +91,7 @@ class GraphData(BaseModel):
     fixed_inputs: dict[PortID, OutputLoc] = {}
     graph_inputs: set[PortID] = set()
     graph_output_idx: NodeIndex | None = None
+    value_refs: list[ValueRef] = Field(exclude=True, default=[])
 
     def add(self, node: NodeDef) -> Callable[[PortID], ValueRef]:
         idx = len(self.nodes)
@@ -141,3 +143,81 @@ class GraphData(BaseModel):
 
         actual_inputs = fixed_inputs.union(provided_inputs)
         return self.graph_inputs - actual_inputs
+
+    def func(self, name: str, inputs: dict[str, int] | None = None) -> "GraphData":
+        inputs = {k: self.value_refs[v] for k, v in inputs.items()} if inputs else {}
+        self.value_refs.append(self.add(Func(name, inputs))(Labels.VALUE))
+        return self
+
+    def eval(self, body: "GraphData", n_inputs: int = 0) -> "GraphData":
+        if len(self.nodes) < n_inputs:
+            raise ValueError("Cannot add an eval, not enough nodes.")
+        inputs = {f"{x}": self.value_refs[-(n_inputs + x) - 1] for x in range(n_inputs)}
+        self.value_refs.append(self.add(Eval(body, inputs))(Labels.VALUE))
+        return self
+
+    def loop(
+        self,
+        body: "GraphData",
+        loop_condition: str,
+        inputs: dict[str, int] | None = None,
+    ) -> "GraphData":
+        l_body = self.add(Const(body))(Labels.VALUE)
+        inputs = {k: self.value_refs[v] for k, v in inputs.items()} if inputs else {}
+        self.value_refs.append(
+            self.add(Loop(l_body, inputs, loop_condition))(Labels.VALUE)
+        )
+        return self
+
+    def map(self, body: "GraphData", n_inputs: int = 0) -> "GraphData":
+        if len(self.nodes) < n_inputs:
+            raise ValueError("Cannot add an eval, not enough nodes.")
+        inputs = {f"{x}": self.value_refs[-(n_inputs + x) - 1] for x in range(n_inputs)}
+        m_body = self.const(body)
+
+        map_def = Map(
+            m_body, self.value_refs[-1][0], Labels.VALUE, Labels.VALUE, inputs
+        )
+        self.value_refs.append(self.add(map_def)(Labels.VALUE))
+        return self
+
+    def const(self, value: Jsonable) -> "GraphData":
+        self.value_refs.append(self.add(Const(value))(Labels.VALUE))
+        return self
+
+    def ifelse(self) -> "GraphData":
+        if len(self.nodes) < 3:
+            raise ValueError("Cannot add an eifelse, not enough nodes.")
+        self.value_refs.append(
+            self.add(
+                IfElse(self.value_refs[-3], self.value_refs[-2], self.value_refs[-1])
+            )
+        )
+        return self
+
+    def efelse(self) -> "GraphData":
+        if len(self.nodes) < 3:
+            raise ValueError("Cannot add an eifelse, not enough nodes.")
+        self.value_refs.append(
+            self.add(
+                EagerIfElse(
+                    self.value_refs[-3], self.value_refs[-2], self.value_refs[-1]
+                )
+            )
+        )
+        return self
+
+    def input(self, name: str = Labels.VALUE) -> "GraphData":
+        self.value_refs.append(self.add(Input(name))(name))
+        return self
+
+    def output(self, outputs: str | dict[str, int] = Labels.VALUE) -> "GraphData":
+        # multi outputs not supported yet
+        if len(self.nodes) == 0:
+            raise ValueError("Cannot add an output to an empty graph.")
+        if isinstance(outputs, dict):
+            outputs = {k: self.value_refs[v] for k, v in outputs.items()}
+            self.value_refs.append(self.add(Output(outputs)))
+        else:
+            self.value_refs.append(self.add(Output({outputs: self.value_refs[-1]})))
+        return self


### PR DESCRIPTION
I've created a draft for a simplified builder interface that lets you chain nodes.
I made a minimal working example, the `Graphdata` is not completely done.
I provided some defaults, e.g. `output()` will consume the port `Labels.VALUE` from the previously added node.
For multiple inputs, you can provide a `dict[str, int]` where the values are the index of the node in the chain to add.
I'm not super happy with this solution so open to suggestions.
As soon as you have multiple outputs it can get quite confusing, as the defaults no longer make sense.

An alternative approach would be similar to `networkx` where you provide all the nodes and edges upfront.
For this approach, I couldn't find a good way to provide the port information.
you could have something like this though:

```python
nodes =  [Const(1),Const(2),Func("builtins.iadd"),Output()]
edges = [(0,2,"a"),(1,2,"b"),(2,3)] # without label use "value"
```
