### PR TITLE
chore: use proper match in vis

### DIFF
--- a/tierkreis_visualization/tierkreis_visualization/routers/workflows.py
+++ b/tierkreis_visualization/tierkreis_visualization/routers/workflows.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any
+from typing import Any, assert_never
 from uuid import UUID
 
 from fastapi import APIRouter, Request
@@ -7,6 +7,7 @@ from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 from starlette.responses import JSONResponse, PlainTextResponse
 from tierkreis.controller.data.location import Loc, WorkerCallArgs
+from tierkreis.exceptions import TierkreisError
 from watchfiles import awatch
 
 from tierkreis_visualization.config import CONFIG, get_storage, templates
@@ -43,51 +44,58 @@ def get_errored_nodes(workflow_id: UUID) -> list[Loc]:
     return [parse_node_location(node) for node in errored_nodes.split("\n")]
 
 
-def get_node_data(workflow_id: UUID, node_location: Loc) -> dict[str, Any]:
+def get_node_data(workflow_id: UUID, loc: Loc) -> dict[str, Any]:
     storage = get_storage(workflow_id)
     errored_nodes = get_errored_nodes(workflow_id)
+    node = storage.read_node_def(loc)
+    ctx: dict[str, Any] = {}
+    match node.type:
 
-    try:
-        definition = storage.read_worker_call_args(node_location)
-    except FileNotFoundError:
-        return {
-            "breadcrumbs": breadcrumbs(workflow_id, node_location),
-            "url": f"/workflows/{workflow_id}/nodes/{node_location}",
-            "node_location": str(node_location),
-            "name": "unavailable.jinja",
-        }
+        case "eval":
+            data = get_eval_node(storage, loc, errored_nodes)
+            name = "eval.jinja"
+            ctx = PyGraph(nodes=data.nodes, edges=data.edges).model_dump()
 
-    node = storage.read_node_def(node_location)
+        case "loop":
+            data = get_loop_node(storage, loc, errored_nodes)
+            name = "loop.jinja"
+            ctx = PyGraph(nodes=data.nodes, edges=data.edges).model_dump()
 
-    if node.type == "eval":
-        data = get_eval_node(storage, node_location, errored_nodes)
-        name = "eval.jinja"
-        ctx: dict[str, Any] = PyGraph(nodes=data.nodes, edges=data.edges).model_dump(
-            by_alias=True
-        )
+        case "map":
+            data = get_map_node(storage, loc, node, errored_nodes)
+            name = "map.jinja"
+            ctx = PyGraph(nodes=data.nodes, edges=data.edges).model_dump()
 
-    elif node.type == "loop":
-        data = get_loop_node(storage, node_location, errored_nodes)
-        name = "loop.jinja"
-        ctx = PyGraph(nodes=data.nodes, edges=data.edges).model_dump(by_alias=True)
+        case "function":
+            try:
+                definition = storage.read_worker_call_args(loc)
+            except FileNotFoundError:
+                return {
+                    "breadcrumbs": breadcrumbs(workflow_id, loc),
+                    "url": f"/workflows/{workflow_id}/nodes/{loc}",
+                    "node_location": str(loc),
+                    "name": "unavailable.jinja",
+                }
+            data = get_function_node(storage, loc)
+            name = "function.jinja"
+            ctx = {"definition": definition.model_dump(), "data": data}
 
-    elif node.type == "map":
-        data = get_map_node(storage, node_location, node, errored_nodes)
-        name = "map.jinja"
-        ctx = PyGraph(nodes=data.nodes, edges=data.edges).model_dump(by_alias=True)
+        case "const" | "ifelse" | "eifelse" | "input" | "output":
+            name = "fallback.jinja"
+            parent = loc.parent()
+            if parent is None:
+                raise TierkreisError("Visualisable node should have parent.")
 
-    elif node.type == "function":
-        data = get_function_node(storage, node_location)
-        name = "function.jinja"
-        ctx = {"definition": definition.model_dump(), "data": data}
+            inputs = {k: (parent.N(i), p) for k, (i, p) in node.inputs.items()}
+            outputs = {k: (loc, k) for k in storage.read_output_ports(loc)}
+            ctx = {"node": node, "inputs": inputs, "outputs": outputs}
 
-    else:
-        name = "fallback.html"
-        ctx = {"definition": definition.model_dump()}
+        case _:
+            assert_never(node)
 
-    ctx["breadcrumbs"] = breadcrumbs(workflow_id, node_location)
-    ctx["url"] = f"/workflows/{workflow_id}/nodes/{node_location}"
-    ctx["node_location"] = str(node_location)
+    ctx["breadcrumbs"] = breadcrumbs(workflow_id, loc)
+    ctx["url"] = f"/workflows/{workflow_id}/nodes/{loc}"
+    ctx["node_location"] = str(loc)
     ctx["name"] = name
 
     return ctx
@@ -128,11 +136,15 @@ def get_input(workflow_id: UUID, node_location_str: str, port_name: str):
 
 @router.get("/{workflow_id}/nodes/{node_location_str}/outputs/{port_name}")
 def get_output(workflow_id: UUID, node_location_str: str, port_name: str):
-    node_location = parse_node_location(node_location_str)
-    storage = get_storage(workflow_id)
-    definition = storage.read_worker_call_args(node_location)
+    output_file = (
+        CONFIG.tierkreis_path
+        / str(workflow_id)
+        / node_location_str
+        / "outputs"
+        / port_name
+    )
 
-    with open(definition.outputs[port_name], "rb") as fh:
+    with open(output_file, "rb") as fh:
         return JSONResponse(json.loads(fh.read()))
 
 

--- a/tierkreis_visualization/tierkreis_visualization/routers/workflows.py
+++ b/tierkreis_visualization/tierkreis_visualization/routers/workflows.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel
 from starlette.responses import JSONResponse, PlainTextResponse
 from tierkreis.controller.data.location import Loc, WorkerCallArgs
 from tierkreis.exceptions import TierkreisError
-from watchfiles import awatch
+from watchfiles import awatch  # type: ignore
 
 from tierkreis_visualization.config import CONFIG, get_storage, templates
 from tierkreis_visualization.data.eval import get_eval_node
@@ -50,7 +50,6 @@ def get_node_data(workflow_id: UUID, loc: Loc) -> dict[str, Any]:
     node = storage.read_node_def(loc)
     ctx: dict[str, Any] = {}
     match node.type:
-
         case "eval":
             data = get_eval_node(storage, loc, errored_nodes)
             name = "eval.jinja"

--- a/tierkreis_visualization/tierkreis_visualization/templates/fallback.jinja
+++ b/tierkreis_visualization/tierkreis_visualization/templates/fallback.jinja
@@ -12,13 +12,15 @@
       {{ breadcrumbs_macro(breadcrumbs) }}
 
       <script>
-        function openLink(path) {
-          console.log(`${window.location.href}/${path}`);
-          window.open(`${window.location.href}/${path}`, (target = "_blank"));
+        function openOutput(loc, port) {
+          /** @type {URL} */
+          const url = new URL(window.location.href);
+          url.pathname = url.pathname.split("/").slice(0, -1).join("/")
+          url.pathname += `/${loc}/outputs/${port}`
+          open(url, "_blank")
         }
       </script>
-      <h1 style="font-size: 1.75rem;
-    font-weight: 500;">{{ definition.function_name }}</h1>
+      <h1 style="font-size: 1.75rem; font-weight: 500;">{{ node.type }}</h1>
 
       <ul>
         <li>
@@ -29,12 +31,10 @@
     font-size: 1.125rem;">Inputs</span>
 
               <ul>
-              {% for input,path in definition.inputs.items() %}
+              {% for k, (loc, port) in inputs.items() %}
               <li>
-                <span class="divLink" onclick="openLink('inputs/{{ input }}')"
-                  >{{ input }}</span
-                >
-                ({{ path }})
+                <span class="divLink" onclick="openOutput('{{ loc }}', '{{ port }}')">{{ k }}</span>
+                ({{ loc }}, {{ port }})
               </li>
               {% endfor %}
           </ul>
@@ -47,17 +47,14 @@
     display: block;
     font-size: 1.125rem;">Outputs</span>
           <ul>
-            {% for output,path in definition.outputs.items() %}
-            <li>
-              <span class="divLink" onclick="openLink('outputs/{{ output }}')"
-                >{{ output }}</span
-              >
-              ({{ path }})
-            </li>
+            {% for k, (loc, port) in outputs.items() %}
+              <li>
+                <span class="divLink" onclick="openOutput('{{ loc }}', '{{ port }}')">{{ k }}</span>
+                ({{ loc }}, {{ port }})
+              </li>
             {% endfor %}
           </ul>
         </li>
-        <li><span class="divLink" onclick="openLink('logs')">logs</span></li>
       </ul>
     </main>
   </body>


### PR DESCRIPTION
Use an exhaustive pattern match to give static errors when we add a node type. 

* Move reading of the worker call args into the function alone. This will allow us to remove the double call to `read_worker_call_args` in the main repo.
* Use `read_output_ports` for nodes that are not worker functions.
* Update `fallback.html` to `fallback.jinja` so to account for different shape of data.
