### PR TITLE
chore: use node def to indicate a node has started

### DIFF
--- a/tierkreis/tierkreis/controller/start.py
+++ b/tierkreis/tierkreis/controller/start.py
@@ -79,7 +79,6 @@ def start(
         raise TierkreisError(f"{node.type} node must have parent Loc.")
 
     ins = {k: (parent.N(idx), p) for k, (idx, p) in node.inputs.items()}
-    storage.write_worker_call_args(node_location, node.type, ins, output_list)
 
     logger.debug(f"start {node_location} {node} {ins} {output_list}")
     if node.type == "function":

--- a/tierkreis/tierkreis/controller/storage/filestorage.py
+++ b/tierkreis/tierkreis/controller/storage/filestorage.py
@@ -180,7 +180,7 @@ class ControllerFileStorage:
         return [x.name for x in dir_list if x.is_file()]
 
     def is_node_started(self, node_location: Loc) -> bool:
-        return Path(self._worker_call_args_path(node_location)).exists()
+        return Path(self._nodedef_path(node_location)).exists()
 
     def is_node_finished(self, node_location: Loc) -> bool:
         return self._done_path(node_location).exists()

--- a/tierkreis/tierkreis/controller/storage/walk.py
+++ b/tierkreis/tierkreis/controller/storage/walk.py
@@ -58,7 +58,6 @@ def walk_node(
 
     node = graph.nodes[idx]
     node_run_data = NodeRunData(loc, node, list(graph.node_outputs[idx]))
-    storage.write_node_def(loc, node)
 
     result = WalkResult([], [])
     if unfinished_results(result, storage, parent, node, graph):

--- a/tierkreis_visualization/tierkreis_visualization/routers/workflows.py
+++ b/tierkreis_visualization/tierkreis_visualization/routers/workflows.py
@@ -47,7 +47,17 @@ def get_errored_nodes(workflow_id: UUID) -> list[Loc]:
 def get_node_data(workflow_id: UUID, loc: Loc) -> dict[str, Any]:
     storage = get_storage(workflow_id)
     errored_nodes = get_errored_nodes(workflow_id)
-    node = storage.read_node_def(loc)
+
+    try:
+        node = storage.read_node_def(loc)
+    except FileNotFoundError:
+        return {
+            "breadcrumbs": breadcrumbs(workflow_id, loc),
+            "url": f"/workflows/{workflow_id}/nodes/{loc}",
+            "node_location": str(loc),
+            "name": "unavailable.jinja",
+        }
+
     ctx: dict[str, Any] = {}
     match node.type:
         case "eval":


### PR DESCRIPTION
Small tidy up that we will need to do at some point. After this we only use worker call args for worker nodes. Gets rid of the strange looking double call to `write_worker_call_args` in `start`.