### PR TITLE
fix: keep order of generics in format_pnamedmodel

### DIFF
--- a/examples/example_workers/substitution_worker/stubs.py
+++ b/examples/example_workers/substitution_worker/stubs.py
@@ -1,19 +1,18 @@
 """Code generated from substitution_worker namespace. Please do not edit."""
 
-# ruff: noqa: F821
 from typing import NamedTuple
 from tierkreis.controller.data.models import TKR, OpaqueType
 
 
 class substitute(NamedTuple):
-    circuit: TKR[OpaqueType["pytket._tket.circuit.Circuit"]]
-    a: TKR[float]
-    b: TKR[float]
-    c: TKR[float]
+    circuit: TKR[OpaqueType["pytket._tket.circuit.Circuit"]]  # noqa: F821 # fmt: skip
+    a: TKR[float]  # noqa: F821 # fmt: skip
+    b: TKR[float]  # noqa: F821 # fmt: skip
+    c: TKR[float]  # noqa: F821 # fmt: skip
 
     @staticmethod
-    def out() -> type[TKR[OpaqueType["pytket._tket.circuit.Circuit"]]]:
-        return TKR[OpaqueType["pytket._tket.circuit.Circuit"]]
+    def out() -> type[TKR[OpaqueType["pytket._tket.circuit.Circuit"]]]:  # noqa: F821 # fmt: skip
+        return TKR[OpaqueType["pytket._tket.circuit.Circuit"]]  # noqa: F821 # fmt: skip
 
     @property
     def namespace(self) -> str:

--- a/tierkreis/tierkreis/builtins/stubs.py
+++ b/tierkreis/tierkreis/builtins/stubs.py
@@ -4,9 +4,9 @@ from typing import NamedTuple, Sequence, TypeVar, Generic
 from tierkreis.controller.data.models import TKR
 from tierkreis.controller.data.types import PType
 
-U = TypeVar("U", bound=PType)
 A = TypeVar("A", bound=PType)
 T = TypeVar("T", bound=PType)
+U = TypeVar("U", bound=PType)
 V = TypeVar("V", bound=PType)
 
 

--- a/tierkreis/tierkreis/codegen.py
+++ b/tierkreis/tierkreis/codegen.py
@@ -2,12 +2,7 @@ from types import NoneType
 from typing import assert_never, get_args, get_origin
 from pydantic import BaseModel
 from tierkreis.controller.data.core import PortID
-from tierkreis.controller.data.models import (
-    PModel,
-    PNamedModel,
-    generics_in_pmodel,
-    is_pnamedmodel,
-)
+from tierkreis.controller.data.models import PModel, PNamedModel, is_pnamedmodel
 from tierkreis.controller.data.types import (
     DictConvertible,
     ListConvertible,
@@ -98,13 +93,14 @@ def format_typevars(generics: set[str]) -> str:
 
 def format_pnamedmodel(pnamedmodel: type[PNamedModel]) -> str:
     origin = get_origin(pnamedmodel)
+    args = get_args(pnamedmodel)
     if origin is not None:
         pnamedmodel = origin
 
     outs = {format_annotation(k, v) for k, v in pnamedmodel.__annotations__.items()}
     outs_str = "\n    ".join(outs)
 
-    generics = generics_in_pmodel(pnamedmodel)
+    generics = [str(x) for x in args]
     generics_str = f", Generic[{', '.join(generics)}]" if generics else ""
 
     return f"""


### PR DESCRIPTION
The order can matter in the references classes. I don't think it matters in the classes corresponding to functions.