### PR TITLE
chore: create class portmapping

### DIFF
--- a/examples/example_workers/auth_worker/main.py
+++ b/examples/example_workers/auth_worker/main.py
@@ -3,6 +3,8 @@ import secrets
 from sys import argv
 from time import time
 from typing import NamedTuple
+
+from tierkreis.controller.data.models import portmapping
 import pyscrypt  # type: ignore
 from tierkreis import Worker
 
@@ -10,6 +12,7 @@ worker = Worker("auth_worker")
 logger = logging.getLogger(__name__)
 
 
+@portmapping
 class EncryptionResult(NamedTuple):
     ciphertext: str
     time_taken: float

--- a/examples/example_workers/auth_worker/stubs.py
+++ b/examples/example_workers/auth_worker/stubs.py
@@ -1,22 +1,21 @@
 """Code generated from auth_worker namespace. Please do not edit."""
 
-# ruff: noqa: F821
 from typing import NamedTuple
 from tierkreis.controller.data.models import TKR
 
 
 class EncryptionResult(NamedTuple):
-    ciphertext: TKR[str]
-    time_taken: TKR[float]
+    ciphertext: TKR[str]  # noqa: F821 # fmt: skip
+    time_taken: TKR[float]  # noqa: F821 # fmt: skip
 
 
 class encrypt(NamedTuple):
-    plaintext: TKR[str]
-    work_factor: TKR[int]
+    plaintext: TKR[str]  # noqa: F821 # fmt: skip
+    work_factor: TKR[int]  # noqa: F821 # fmt: skip
 
     @staticmethod
-    def out() -> type[EncryptionResult]:
-        return EncryptionResult
+    def out() -> type[EncryptionResult]:  # noqa: F821 # fmt: skip
+        return EncryptionResult  # noqa: F821 # fmt: skip
 
     @property
     def namespace(self) -> str:

--- a/tierkreis/tierkreis/builtins/main.py
+++ b/tierkreis/tierkreis/builtins/main.py
@@ -6,6 +6,7 @@ from sys import argv
 from typing import NamedTuple, Sequence
 
 from tierkreis.controller.data.location import WorkerCallArgs
+from tierkreis.controller.data.models import portmapping
 from tierkreis.controller.data.types import PType, bytes_from_ptype, ptype_from_bytes
 from tierkreis.namespace import TierkreisWorkerError
 from tierkreis.worker.storage.protocol import WorkerStorage
@@ -53,6 +54,7 @@ def append[T](v: list[T], a: T) -> list[T]:  # noqa: E741
     return v
 
 
+@portmapping
 class Headed[T: PType](NamedTuple):
     head: T
     rest: list[T]
@@ -110,6 +112,7 @@ def zip_impl[U, V](a: list[U], b: list[V]) -> list[tuple[U, V]]:
     return list(zip(a, b))
 
 
+@portmapping
 class Unzipped[U: PType, V: PType](NamedTuple):
     a: list[U]
     b: list[V]
@@ -126,6 +129,7 @@ def tuple_impl[U, V](a: U, b: V) -> tuple[U, V]:
     return (a, b)
 
 
+@portmapping
 class Untupled[U: PType, V: PType](NamedTuple):
     a: U
     b: V

--- a/tierkreis/tierkreis/builtins/stubs.py
+++ b/tierkreis/tierkreis/builtins/stubs.py
@@ -4,16 +4,15 @@ from typing import NamedTuple, TypeVar, Generic
 from tierkreis.controller.data.models import TKR
 from tierkreis.controller.data.types import PType
 
+A = TypeVar("A", bound=PType)
 T = TypeVar("T", bound=PType)
 U = TypeVar("U", bound=PType)
 V = TypeVar("V", bound=PType)
-U = TypeVar("U", bound=PType)
-A = TypeVar("A", bound=PType)
 
 
-class Unzipped(NamedTuple, Generic[U, V]):
-    a: TKR[list[U]]  # noqa: F821 # fmt: skip
-    b: TKR[list[V]]  # noqa: F821 # fmt: skip
+class Headed(NamedTuple, Generic[T]):
+    head: TKR[T]  # noqa: F821 # fmt: skip
+    rest: TKR[list[T]]  # noqa: F821 # fmt: skip
 
 
 class Untupled(NamedTuple, Generic[U, V]):
@@ -21,9 +20,9 @@ class Untupled(NamedTuple, Generic[U, V]):
     b: TKR[V]  # noqa: F821 # fmt: skip
 
 
-class Headed(NamedTuple, Generic[T]):
-    head: TKR[T]  # noqa: F821 # fmt: skip
-    rest: TKR[list[T]]  # noqa: F821 # fmt: skip
+class Unzipped(NamedTuple, Generic[U, V]):
+    a: TKR[list[U]]  # noqa: F821 # fmt: skip
+    b: TKR[list[V]]  # noqa: F821 # fmt: skip
 
 
 class iadd(NamedTuple):

--- a/tierkreis/tierkreis/codegen.py
+++ b/tierkreis/tierkreis/codegen.py
@@ -47,15 +47,15 @@ def format_ptype(ptype: type[PType]) -> str:
     assert_never(ptype)
 
 
-def format_generics(generics: list[str]) -> str:
-    return f", Generic[{', '.join(generics)}]" if generics else ""
+def format_generics(generics: list[str], in_constructor: bool = True) -> str:
+    prefix = ", Generic" if in_constructor else ""
+    return f"{prefix}[{', '.join(generics)}]" if generics else ""
 
 
 def format_tmodel_type(outputs: type[PModel]) -> str:
     if is_portmapping(outputs):
         args = [str(x) for x in get_args(outputs)]
-        generics_str = f"[{', '.join(args)}]" if args else ""
-        return f"{outputs.__qualname__}{generics_str}"
+        return f"{outputs.__qualname__}{format_generics(args, False)}"
 
     return f"TKR[{format_ptype(outputs)}]"
 

--- a/tierkreis/tierkreis/controller/data/models.py
+++ b/tierkreis/tierkreis/controller/data/models.py
@@ -6,6 +6,7 @@ from typing import (
     Protocol,
     SupportsIndex,
     cast,
+    dataclass_transform,
     get_origin,
     runtime_checkable,
 )
@@ -23,6 +24,12 @@ class PNamedModel(Protocol):
 
     def _asdict(self) -> dict[str, PType]: ...
     def __getitem__(self, key: SupportsIndex, /) -> PType: ...
+
+
+@dataclass_transform()
+def portmapping[T: PNamedModel](cls: type[T]) -> type[T]:
+    setattr(cls, "__tkr_portmapping__", True)
+    return cls
 
 
 PModel = PNamedModel | PType

--- a/tierkreis/tierkreis/controller/data/models.py
+++ b/tierkreis/tierkreis/controller/data/models.py
@@ -14,6 +14,8 @@ from typing_extensions import TypeIs
 from tierkreis.controller.data.core import NodeIndex, PortID, ValueRef
 from tierkreis.controller.data.types import PType, generics_in_ptype
 
+TKR_PORTMAPPING_FLAG = "__tkr_portmapping__"
+
 
 @runtime_checkable
 class PNamedModel(Protocol):
@@ -28,7 +30,7 @@ class PNamedModel(Protocol):
 
 @dataclass_transform()
 def portmapping[T: PNamedModel](cls: type[T]) -> type[T]:
-    setattr(cls, "__tkr_portmapping__", True)
+    setattr(cls, TKR_PORTMAPPING_FLAG, True)
     return cls
 
 
@@ -58,11 +60,11 @@ class TNamedModel(Protocol):
 TModel = TNamedModel | TKR
 
 
-def is_pnamedmodel(o) -> TypeIs[type[PNamedModel]]:
+def is_portmapping(o) -> TypeIs[type[PNamedModel]]:
     origin = get_origin(o)
     if origin is not None:
-        return is_pnamedmodel(origin)
-    return isclass(o) and issubclass(o, PNamedModel)
+        return is_portmapping(origin)
+    return hasattr(o, TKR_PORTMAPPING_FLAG)
 
 
 def is_tnamedmodel(o) -> TypeIs[type[TNamedModel]]:
@@ -87,7 +89,7 @@ def dict_from_tmodel(tmodel: TModel) -> dict[PortID, ValueRef]:
 
 
 def model_fields(model: type[PModel] | type[TModel]) -> list[str]:
-    if is_pnamedmodel(model):
+    if is_portmapping(model):
         return getattr(model, "_fields")
 
     if is_tnamedmodel(model):
@@ -109,7 +111,7 @@ def init_tmodel[T: TModel](tmodel: type[T], refs: list[ValueRef]) -> T:
 
 
 def generics_in_pmodel(pmodel: type[PModel]) -> set[str]:
-    if is_pnamedmodel(pmodel):
+    if is_portmapping(pmodel):
         origin = get_origin(pmodel)
         if origin is not None:
             return generics_in_pmodel(origin)

--- a/tierkreis/tierkreis/namespace.py
+++ b/tierkreis/tierkreis/namespace.py
@@ -39,7 +39,6 @@ class FunctionSpec:
         elif is_portmapping(annotation):
             self.outs = annotation
         elif not is_ptype(annotation):
-            print(dir(annotation))
             raise TierkreisError(f"Expected PModel found {annotation}")
         else:
             self.outs = annotation

--- a/tierkreis/tierkreis/namespace.py
+++ b/tierkreis/tierkreis/namespace.py
@@ -1,17 +1,17 @@
 from dataclasses import dataclass, field
 from logging import getLogger
 from types import NoneType
-from typing import Any
+from typing import Any, Callable
 from tierkreis.controller.data.models import (
     PModel,
     PNamedModel,
-    generics_in_pmodel,
-    is_pnamedmodel,
+    is_portmapping,
 )
-from tierkreis.controller.data.types import PType, generics_in_ptype, is_ptype
+from tierkreis.controller.data.types import PType, is_ptype
 from tierkreis.exceptions import TierkreisError
 
 logger = getLogger(__name__)
+WorkerFunction = Callable[..., PModel]
 
 
 class TierkreisWorkerError(TierkreisError):
@@ -24,27 +24,25 @@ class FunctionSpec:
     namespace: str
     ins: dict[str, type[PType]]
     outs: type[PModel]
-    generics: set[str] = field(default_factory=lambda: set())
+    generics: list[str]
 
     def add_inputs(self, annotations: dict[str, Any]) -> None:
         for name, annotation in annotations.items():
             if not is_ptype(annotation):
                 raise TierkreisError(f"Expected PType found {annotation} {annotations}")
             self.ins[name] = annotation
-            self.generics.update(generics_in_ptype(annotation))
 
     def add_outputs(self, annotation: type | None) -> None:
         if annotation is None:
             self.outs = NoneType
             return
-        elif is_pnamedmodel(annotation):
+        elif is_portmapping(annotation):
             self.outs = annotation
         elif not is_ptype(annotation):
+            print(dir(annotation))
             raise TierkreisError(f"Expected PModel found {annotation}")
         else:
             self.outs = annotation
-
-        self.generics.update(generics_in_pmodel(annotation))
 
 
 @dataclass
@@ -54,10 +52,15 @@ class Namespace:
     generics: set[str] = field(default_factory=lambda: set())
     refs: set[type[PNamedModel]] = field(default_factory=lambda: set())
 
-    def add_from_annotations(self, name: str, annotations: dict[str, Any]) -> None:
+    def add_from_annotations(self, func: WorkerFunction) -> None:
+        name = func.__name__
+        annotations = func.__annotations__
         try:
-            fn = FunctionSpec(name=name, namespace=self.name, ins={}, outs=NoneType)
-            [self.refs.add(v) for k, v in annotations.items() if is_pnamedmodel(v)]
+            generics: list[str] = [str(x) for x in func.__type_params__]
+            fn = FunctionSpec(
+                name=name, namespace=self.name, ins={}, outs=NoneType, generics=generics
+            )
+            [self.refs.add(v) for k, v in annotations.items() if is_portmapping(v)]
             fn.add_inputs({k: v for k, v in annotations.items() if k != "return"})
             fn.add_outputs(annotations["return"])
             self.functions[fn.name] = fn

--- a/tierkreis/tierkreis/worker/worker.py
+++ b/tierkreis/tierkreis/worker/worker.py
@@ -11,12 +11,11 @@ from tierkreis.controller.data.location import WorkerCallArgs
 from tierkreis.controller.data.models import PModel, dict_from_pmodel
 from tierkreis.controller.data.types import PType, bytes_from_ptype, ptype_from_bytes
 from tierkreis.exceptions import TierkreisError
-from tierkreis.namespace import Namespace
+from tierkreis.namespace import Namespace, WorkerFunction
 from tierkreis.worker.storage.filestorage import WorkerFileStorage
 from tierkreis.worker.storage.protocol import WorkerStorage
 
 logger = getLogger(__name__)
-WorkerFunction = Callable[..., PModel]
 PrimitiveTask = Callable[[WorkerCallArgs, WorkerStorage], None]
 
 
@@ -79,7 +78,7 @@ class Worker:
 
         def function_decorator(func: WorkerFunction) -> None:
             func_name = func.__name__
-            self.namespace.add_from_annotations(func.__name__, func.__annotations__)
+            self.namespace.add_from_annotations(func)
 
             def wrapper(node_definition: WorkerCallArgs):
                 kwargs = self._load_args(func, node_definition.inputs)


### PR DESCRIPTION
* Define a decorator `@portmapping` to pick out the `NamedTuple`s whose attributes correspond to different outputs in the graph. Note that we don't yet allow `NamedTuple` as a `PType` but we now have a way of adding it in a less confusing way.
* Add the `@portmapping` to workers defined in this repo.
* Code gen: fix an order of attributes and generics in classes to avoid unnecessary code churn.
* Change `is_pnamed_model` to `is_portmapping` because all calls to `is_pnamed_model` were for the purposes of checking if the object was a port mapping.