### PR TITLE
chore: Simplify graph data nodes

### DIFF
--- a/tierkreis/tierkreis/controller/start.py
+++ b/tierkreis/tierkreis/controller/start.py
@@ -10,7 +10,7 @@ from tierkreis.controller.data.types import bytes_from_ptype, ptype_from_bytes
 from typing_extensions import assert_never
 
 from tierkreis.consts import PACKAGE_PATH
-from tierkreis.controller.data.graph import Eval, GraphData, NodeDef
+from tierkreis.controller.data.graph import Eval, GraphData, HasInputs, NodeDef
 from tierkreis.controller.data.location import Loc, OutputLoc
 from tierkreis.controller.executor.protocol import ControllerExecutor
 from tierkreis.controller.storage.protocol import ControllerStorage
@@ -77,7 +77,10 @@ def start(
     if parent is None:
         raise TierkreisError(f"{node.type} node must have parent Loc.")
 
-    ins = {k: (parent.N(idx), p) for k, (idx, p) in node.inputs.items()}
+    if isinstance(node, HasInputs):
+        ins = {k: (parent.N(idx), p) for k, (idx, p) in node.inputs.items()}
+    else:
+        ins = {}
 
     logger.debug(f"start {node_location} {node} {ins} {output_list}")
     if node.type == "function":

--- a/tierkreis/tierkreis/controller/storage/adjacency.py
+++ b/tierkreis/tierkreis/controller/storage/adjacency.py
@@ -2,7 +2,10 @@ import logging
 from typing import assert_never
 
 from tierkreis.controller.data.core import PortID, ValueRef
-from tierkreis.controller.data.graph import NodeDef
+from tierkreis.controller.data.graph import (
+    HasInputs,
+    NodeDef,
+)
 from tierkreis.controller.data.location import Loc
 from tierkreis.controller.storage.protocol import ControllerStorage
 
@@ -10,7 +13,10 @@ logger = logging.getLogger(__name__)
 
 
 def in_edges(node: NodeDef) -> dict[PortID, ValueRef]:
-    parents = {k: v for k, v in node.inputs.items()}
+    if isinstance(node, (HasInputs)):
+        parents = {k: v for k, v in node.inputs.items()}
+    else:
+        parents = {}
 
     match node.type:
         case "eval":


### PR DESCRIPTION
Simplify the NodeDef structures by removing all input attributes for nodes that never have inputs.

Mostly an optional change but it seems like it would make the graph building more obvious at the cost of more instance checks.