### PR TITLE
feat: input protocols

### DIFF
--- a/examples/example_workers/chemistry_worker/chemistry/molecule.py
+++ b/examples/example_workers/chemistry_worker/chemistry/molecule.py
@@ -51,7 +51,7 @@ def _extract_hamiltonian_rhf(
 
 
 def extract_hamiltonian_rhf(
-    atom: str,
+    atom: list[tuple[str, list[float]]],
     basis: str,
     charge: int = 0,
     spin: int = 0,

--- a/examples/example_workers/chemistry_worker/main.py
+++ b/examples/example_workers/chemistry_worker/main.py
@@ -3,12 +3,12 @@
 # dependencies = ["pydantic", "tierkreis", "pyscf"]
 #
 # [tool.uv.sources]
-# tierkreis = { path = "../../../tierkreis" }
+# tierkreis = { path = "../../../tierkreis", editable = true }
 # ///
 import logging
 from sys import argv
+from typing import NamedTuple
 
-from pydantic import BaseModel
 
 from chemistry.active_space import get_frozen
 from chemistry.molecule import extract_hamiltonian_rhf
@@ -20,18 +20,18 @@ logger = logging.getLogger(__name__)
 worker = Worker("chemistry_worker")
 
 
-class Molecule(BaseModel):
+class Molecule(NamedTuple):
     geometry: list[tuple[str, list[float]]]
     basis: str
     charge: int
 
 
-class CompleteActiveSpace(BaseModel):
+class CompleteActiveSpace(NamedTuple):
     n: int
     n_ele: int
 
 
-class Hamiltonian(BaseModel):
+class Hamiltonian(NamedTuple):
     h0: float
     h1: list[list[float]]
     h2: list[list[list[list[float]]]]

--- a/examples/example_workers/chemistry_worker/main.py
+++ b/examples/example_workers/chemistry_worker/main.py
@@ -6,12 +6,12 @@
 # tierkreis = { path = "../../../tierkreis" }
 # ///
 import logging
-from pathlib import Path
 from sys import argv
+
+from pydantic import BaseModel
 
 from chemistry.active_space import get_frozen
 from chemistry.molecule import extract_hamiltonian_rhf
-from pydantic import BaseModel
 
 from tierkreis import Worker
 
@@ -20,31 +20,39 @@ logger = logging.getLogger(__name__)
 worker = Worker("chemistry_worker")
 
 
-class HamiltonianResult(BaseModel):
+class Molecule(BaseModel):
+    geometry: list[tuple[str, list[float]]]
+    basis: str
+    charge: int
+
+
+class CompleteActiveSpace(BaseModel):
+    n: int
+    n_ele: int
+
+
+class Hamiltonian(BaseModel):
     h0: float
-    h1: list
-    h2: list
+    h1: list[list[float]]
+    h2: list[list[list[list[float]]]]
 
 
 @worker.task()
 def make_ham(
-    geometry: str, basis: str, charge: int, mo_occ: list[int], n_cas: int, n_elecas: int
-) -> HamiltonianResult:
+    molecule: Molecule,
+    mo_occ: list[int],
+    cas: CompleteActiveSpace,
+) -> Hamiltonian:
     # Construct the frozen orbital lists.
-    frozen = get_frozen(mo_occ, n_cas, n_elecas)
+    frozen = get_frozen(mo_occ, cas.n, cas.n_ele)
     h0, h1, h2 = extract_hamiltonian_rhf(
-        geometry,
-        basis,
-        charge=charge,
+        molecule.geometry,
+        molecule.basis,
+        charge=molecule.charge,
         frozen=frozen,
     )
-    return HamiltonianResult(h0=h0, h1=h1.tolist(), h2=h2.tolist())
-
-
-def main() -> None:
-    node_definition_path = argv[1]
-    worker.run(Path(node_definition_path))
+    return Hamiltonian(h0=h0, h1=h1.tolist(), h2=h2.tolist())
 
 
 if __name__ == "__main__":
-    main()
+    worker.app(argv)

--- a/examples/example_workers/chemistry_worker/stubs.py
+++ b/examples/example_workers/chemistry_worker/stubs.py
@@ -1,17 +1,43 @@
 """Code generated from chemistry_worker namespace. Please do not edit."""
 
-from typing import NamedTuple
-from tierkreis.controller.data.models import TKR, OpaqueType
+from typing import NamedTuple, Protocol
+from tierkreis.controller.data.models import TKR
+from tierkreis.controller.data.types import Struct
+
+
+class CompleteActiveSpace(Struct, Protocol):
+    @property
+    def n_ele(self) -> int: ...  # noqa: F821 # fmt: skip
+    @property
+    def n(self) -> int: ...  # noqa: F821 # fmt: skip
+
+
+class Molecule(Struct, Protocol):
+    @property
+    def basis(self) -> str: ...  # noqa: F821 # fmt: skip
+    @property
+    def geometry(self) -> list[tuple[str, list[float]]]: ...  # noqa: F821 # fmt: skip
+    @property
+    def charge(self) -> int: ...  # noqa: F821 # fmt: skip
+
+
+class Hamiltonian(Struct, Protocol):
+    @property
+    def h2(self) -> list[list[list[list[float]]]]: ...  # noqa: F821 # fmt: skip
+    @property
+    def h0(self) -> float: ...  # noqa: F821 # fmt: skip
+    @property
+    def h1(self) -> list[list[float]]: ...  # noqa: F821 # fmt: skip
 
 
 class make_ham(NamedTuple):
-    molecule: TKR[OpaqueType["__main__.Molecule"]]  # noqa: F821 # fmt: skip
+    molecule: TKR[Molecule]  # noqa: F821 # fmt: skip
     mo_occ: TKR[list[int]]  # noqa: F821 # fmt: skip
-    cas: TKR[OpaqueType["__main__.CompleteActiveSpace"]]  # noqa: F821 # fmt: skip
+    cas: TKR[CompleteActiveSpace]  # noqa: F821 # fmt: skip
 
     @staticmethod
-    def out() -> type[TKR[OpaqueType["__main__.Hamiltonian"]]]:  # noqa: F821 # fmt: skip
-        return TKR[OpaqueType["__main__.Hamiltonian"]]  # noqa: F821 # fmt: skip
+    def out() -> type[TKR[Hamiltonian]]:  # noqa: F821 # fmt: skip
+        return TKR[Hamiltonian]  # noqa: F821 # fmt: skip
 
     @property
     def namespace(self) -> str:

--- a/examples/example_workers/chemistry_worker/stubs.py
+++ b/examples/example_workers/chemistry_worker/stubs.py
@@ -1,0 +1,18 @@
+"""Code generated from chemistry_worker namespace. Please do not edit."""
+
+from typing import NamedTuple
+from tierkreis.controller.data.models import TKR, OpaqueType
+
+
+class make_ham(NamedTuple):
+    molecule: TKR[OpaqueType["__main__.Molecule"]]  # noqa: F821 # fmt: skip
+    mo_occ: TKR[list[int]]  # noqa: F821 # fmt: skip
+    cas: TKR[OpaqueType["__main__.CompleteActiveSpace"]]  # noqa: F821 # fmt: skip
+
+    @staticmethod
+    def out() -> type[TKR[OpaqueType["__main__.Hamiltonian"]]]:  # noqa: F821 # fmt: skip
+        return TKR[OpaqueType["__main__.Hamiltonian"]]  # noqa: F821 # fmt: skip
+
+    @property
+    def namespace(self) -> str:
+        return "chemistry_worker"

--- a/examples/example_workers/chemistry_worker/stubs.py
+++ b/examples/example_workers/chemistry_worker/stubs.py
@@ -5,29 +5,29 @@ from tierkreis.controller.data.models import TKR
 from tierkreis.controller.data.types import Struct
 
 
-class Molecule(Struct, Protocol):
+class CompleteActiveSpace(Struct, Protocol):
     @property
-    def basis(self) -> str: ...  # noqa: F821 # fmt: skip
+    def n(self) -> int: ...  # noqa: F821 # fmt: skip
     @property
-    def geometry(self) -> list[tuple[str, list[float]]]: ...  # noqa: F821 # fmt: skip
-    @property
-    def charge(self) -> int: ...  # noqa: F821 # fmt: skip
+    def n_ele(self) -> int: ...  # noqa: F821 # fmt: skip
 
 
 class Hamiltonian(Struct, Protocol):
     @property
-    def h1(self) -> list[list[float]]: ...  # noqa: F821 # fmt: skip
-    @property
     def h0(self) -> float: ...  # noqa: F821 # fmt: skip
+    @property
+    def h1(self) -> list[list[float]]: ...  # noqa: F821 # fmt: skip
     @property
     def h2(self) -> list[list[list[list[float]]]]: ...  # noqa: F821 # fmt: skip
 
 
-class CompleteActiveSpace(Struct, Protocol):
+class Molecule(Struct, Protocol):
     @property
-    def n_ele(self) -> int: ...  # noqa: F821 # fmt: skip
+    def basis(self) -> str: ...  # noqa: F821 # fmt: skip
     @property
-    def n(self) -> int: ...  # noqa: F821 # fmt: skip
+    def charge(self) -> int: ...  # noqa: F821 # fmt: skip
+    @property
+    def geometry(self) -> list[tuple[str, list[float]]]: ...  # noqa: F821 # fmt: skip
 
 
 class make_ham(NamedTuple):

--- a/examples/example_workers/chemistry_worker/stubs.py
+++ b/examples/example_workers/chemistry_worker/stubs.py
@@ -5,13 +5,6 @@ from tierkreis.controller.data.models import TKR
 from tierkreis.controller.data.types import Struct
 
 
-class CompleteActiveSpace(Struct, Protocol):
-    @property
-    def n_ele(self) -> int: ...  # noqa: F821 # fmt: skip
-    @property
-    def n(self) -> int: ...  # noqa: F821 # fmt: skip
-
-
 class Molecule(Struct, Protocol):
     @property
     def basis(self) -> str: ...  # noqa: F821 # fmt: skip
@@ -23,11 +16,18 @@ class Molecule(Struct, Protocol):
 
 class Hamiltonian(Struct, Protocol):
     @property
-    def h2(self) -> list[list[list[list[float]]]]: ...  # noqa: F821 # fmt: skip
+    def h1(self) -> list[list[float]]: ...  # noqa: F821 # fmt: skip
     @property
     def h0(self) -> float: ...  # noqa: F821 # fmt: skip
     @property
-    def h1(self) -> list[list[float]]: ...  # noqa: F821 # fmt: skip
+    def h2(self) -> list[list[list[list[float]]]]: ...  # noqa: F821 # fmt: skip
+
+
+class CompleteActiveSpace(Struct, Protocol):
+    @property
+    def n_ele(self) -> int: ...  # noqa: F821 # fmt: skip
+    @property
+    def n(self) -> int: ...  # noqa: F821 # fmt: skip
 
 
 class make_ham(NamedTuple):

--- a/examples/example_workers/chemistry_worker/stubs.py
+++ b/examples/example_workers/chemistry_worker/stubs.py
@@ -6,28 +6,20 @@ from tierkreis.controller.data.types import Struct
 
 
 class CompleteActiveSpace(Struct, Protocol):
-    @property
-    def n(self) -> int: ...  # noqa: F821 # fmt: skip
-    @property
-    def n_ele(self) -> int: ...  # noqa: F821 # fmt: skip
+    n: int  # noqa: F821 # fmt: skip
+    n_ele: int  # noqa: F821 # fmt: skip
 
 
 class Hamiltonian(Struct, Protocol):
-    @property
-    def h0(self) -> float: ...  # noqa: F821 # fmt: skip
-    @property
-    def h1(self) -> list[list[float]]: ...  # noqa: F821 # fmt: skip
-    @property
-    def h2(self) -> list[list[list[list[float]]]]: ...  # noqa: F821 # fmt: skip
+    h0: float  # noqa: F821 # fmt: skip
+    h1: list[list[float]]  # noqa: F821 # fmt: skip
+    h2: list[list[list[list[float]]]]  # noqa: F821 # fmt: skip
 
 
 class Molecule(Struct, Protocol):
-    @property
-    def basis(self) -> str: ...  # noqa: F821 # fmt: skip
-    @property
-    def charge(self) -> int: ...  # noqa: F821 # fmt: skip
-    @property
-    def geometry(self) -> list[tuple[str, list[float]]]: ...  # noqa: F821 # fmt: skip
+    basis: str  # noqa: F821 # fmt: skip
+    charge: int  # noqa: F821 # fmt: skip
+    geometry: list[tuple[str, list[float]]]  # noqa: F821 # fmt: skip
 
 
 class make_ham(NamedTuple):

--- a/examples/example_workers/qsci_worker/main.py
+++ b/examples/example_workers/qsci_worker/main.py
@@ -3,14 +3,13 @@
 # dependencies = ["pydantic", "pytket", "pytket-qiskit", "tierkreis"]
 #
 # [tool.uv.sources]
-# tierkreis = { path = "../../../tierkreis" }
+# tierkreis = { path = "../../../tierkreis", editable = true }
 # ///
 import logging
 from sys import argv
 from typing import Counter, NamedTuple, cast
 
 import numpy as np
-from pydantic import BaseModel
 from pytket._tket.circuit import Circuit
 from pytket.backends.backendresult import BackendResult
 from pytket.circuit import Qubit
@@ -29,18 +28,18 @@ logger = logging.getLogger(__name__)
 worker = Worker("qsci_worker")
 
 
-class Molecule(BaseModel):
+class Molecule(NamedTuple):
     geometry: list[tuple[str, list[float]]]
     basis: str
     charge: int
 
 
-class CompleteActiveSpace(BaseModel):
+class CompleteActiveSpace(NamedTuple):
     n: int
     n_ele: int
 
 
-class Hamiltonian(BaseModel):
+class Hamiltonian(NamedTuple):
     h0: float
     h1: list[list[float]]
     h2: list[list[list[list[float]]]]

--- a/examples/example_workers/qsci_worker/stubs.py
+++ b/examples/example_workers/qsci_worker/stubs.py
@@ -6,19 +6,14 @@ from tierkreis.controller.data.types import Struct
 
 
 class CompleteActiveSpace(Struct, Protocol):
-    @property
-    def n(self) -> int: ...  # noqa: F821 # fmt: skip
-    @property
-    def n_ele(self) -> int: ...  # noqa: F821 # fmt: skip
+    n: int  # noqa: F821 # fmt: skip
+    n_ele: int  # noqa: F821 # fmt: skip
 
 
 class Hamiltonian(Struct, Protocol):
-    @property
-    def h0(self) -> float: ...  # noqa: F821 # fmt: skip
-    @property
-    def h1(self) -> list[list[float]]: ...  # noqa: F821 # fmt: skip
-    @property
-    def h2(self) -> list[list[list[list[float]]]]: ...  # noqa: F821 # fmt: skip
+    h0: float  # noqa: F821 # fmt: skip
+    h1: list[list[float]]  # noqa: F821 # fmt: skip
+    h2: list[list[list[list[float]]]]  # noqa: F821 # fmt: skip
 
 
 class state_prep(NamedTuple):

--- a/examples/example_workers/qsci_worker/stubs.py
+++ b/examples/example_workers/qsci_worker/stubs.py
@@ -1,17 +1,34 @@
 """Code generated from qsci_worker namespace. Please do not edit."""
 
-from typing import NamedTuple
+from typing import NamedTuple, Protocol
 from tierkreis.controller.data.models import TKR, OpaqueType
+from tierkreis.controller.data.types import Struct
+
+
+class CompleteActiveSpace(Struct, Protocol):
+    @property
+    def n_ele(self) -> int: ...  # noqa: F821 # fmt: skip
+    @property
+    def n(self) -> int: ...  # noqa: F821 # fmt: skip
+
+
+class Hamiltonian(Struct, Protocol):
+    @property
+    def h0(self) -> float: ...  # noqa: F821 # fmt: skip
+    @property
+    def h2(self) -> list[list[list[list[float]]]]: ...  # noqa: F821 # fmt: skip
+    @property
+    def h1(self) -> list[list[float]]: ...  # noqa: F821 # fmt: skip
 
 
 class state_prep(NamedTuple):
-    ham_init: TKR[OpaqueType["__main__.Hamiltonian"]]  # noqa: F821 # fmt: skip
+    ham_init: TKR[Hamiltonian]  # noqa: F821 # fmt: skip
     reference_state: TKR[list[int]]  # noqa: F821 # fmt: skip
     max_iteration_prep: TKR[int]  # noqa: F821 # fmt: skip
     atol: TKR[float]  # noqa: F821 # fmt: skip
     mo_occ: TKR[list[int]]  # noqa: F821 # fmt: skip
-    cas_init: TKR[OpaqueType["__main__.CompleteActiveSpace"]]  # noqa: F821 # fmt: skip
-    cas_hsim: TKR[OpaqueType["__main__.CompleteActiveSpace"]]  # noqa: F821 # fmt: skip
+    cas_init: TKR[CompleteActiveSpace]  # noqa: F821 # fmt: skip
+    cas_hsim: TKR[CompleteActiveSpace]  # noqa: F821 # fmt: skip
 
     @staticmethod
     def out() -> type[TKR[OpaqueType["pytket._tket.circuit.Circuit"]]]:  # noqa: F821 # fmt: skip
@@ -23,12 +40,12 @@ class state_prep(NamedTuple):
 
 
 class circuits_from_hamiltonians(NamedTuple):
-    ham_init: TKR[OpaqueType["__main__.Hamiltonian"]]  # noqa: F821 # fmt: skip
-    ham_hsim: TKR[OpaqueType["__main__.Hamiltonian"]]  # noqa: F821 # fmt: skip
+    ham_init: TKR[Hamiltonian]  # noqa: F821 # fmt: skip
+    ham_hsim: TKR[Hamiltonian]  # noqa: F821 # fmt: skip
     adapt_circuit: TKR[OpaqueType["pytket._tket.circuit.Circuit"]]  # noqa: F821 # fmt: skip
     t_step_list: TKR[list[float]]  # noqa: F821 # fmt: skip
-    cas_init: TKR[OpaqueType["__main__.CompleteActiveSpace"]]  # noqa: F821 # fmt: skip
-    cas_hsim: TKR[OpaqueType["__main__.CompleteActiveSpace"]]  # noqa: F821 # fmt: skip
+    cas_init: TKR[CompleteActiveSpace]  # noqa: F821 # fmt: skip
+    cas_hsim: TKR[CompleteActiveSpace]  # noqa: F821 # fmt: skip
     mo_occ: TKR[list[int]]  # noqa: F821 # fmt: skip
     max_cx_gates: TKR[int]  # noqa: F821 # fmt: skip
 
@@ -42,11 +59,11 @@ class circuits_from_hamiltonians(NamedTuple):
 
 
 class energy_from_results(NamedTuple):
-    ham_hsim: TKR[OpaqueType["__main__.Hamiltonian"]]  # noqa: F821 # fmt: skip
+    ham_hsim: TKR[Hamiltonian]  # noqa: F821 # fmt: skip
     backend_results: TKR[list[OpaqueType["pytket.backends.backendresult.BackendResult"]]]  # noqa: F821 # fmt: skip
     mo_occ: TKR[list[int]]  # noqa: F821 # fmt: skip
-    cas_init: TKR[OpaqueType["__main__.CompleteActiveSpace"]]  # noqa: F821 # fmt: skip
-    cas_hsim: TKR[OpaqueType["__main__.CompleteActiveSpace"]]  # noqa: F821 # fmt: skip
+    cas_init: TKR[CompleteActiveSpace]  # noqa: F821 # fmt: skip
+    cas_hsim: TKR[CompleteActiveSpace]  # noqa: F821 # fmt: skip
 
     @staticmethod
     def out() -> type[TKR[float]]:  # noqa: F821 # fmt: skip

--- a/examples/example_workers/qsci_worker/stubs.py
+++ b/examples/example_workers/qsci_worker/stubs.py
@@ -7,16 +7,16 @@ from tierkreis.controller.data.types import Struct
 
 class CompleteActiveSpace(Struct, Protocol):
     @property
-    def n_ele(self) -> int: ...  # noqa: F821 # fmt: skip
-    @property
     def n(self) -> int: ...  # noqa: F821 # fmt: skip
+    @property
+    def n_ele(self) -> int: ...  # noqa: F821 # fmt: skip
 
 
 class Hamiltonian(Struct, Protocol):
     @property
-    def h1(self) -> list[list[float]]: ...  # noqa: F821 # fmt: skip
-    @property
     def h0(self) -> float: ...  # noqa: F821 # fmt: skip
+    @property
+    def h1(self) -> list[list[float]]: ...  # noqa: F821 # fmt: skip
     @property
     def h2(self) -> list[list[list[list[float]]]]: ...  # noqa: F821 # fmt: skip
 

--- a/examples/example_workers/qsci_worker/stubs.py
+++ b/examples/example_workers/qsci_worker/stubs.py
@@ -14,11 +14,11 @@ class CompleteActiveSpace(Struct, Protocol):
 
 class Hamiltonian(Struct, Protocol):
     @property
+    def h1(self) -> list[list[float]]: ...  # noqa: F821 # fmt: skip
+    @property
     def h0(self) -> float: ...  # noqa: F821 # fmt: skip
     @property
     def h2(self) -> list[list[list[list[float]]]]: ...  # noqa: F821 # fmt: skip
-    @property
-    def h1(self) -> list[list[float]]: ...  # noqa: F821 # fmt: skip
 
 
 class state_prep(NamedTuple):

--- a/examples/example_workers/qsci_worker/stubs.py
+++ b/examples/example_workers/qsci_worker/stubs.py
@@ -1,0 +1,57 @@
+"""Code generated from qsci_worker namespace. Please do not edit."""
+
+from typing import NamedTuple
+from tierkreis.controller.data.models import TKR, OpaqueType
+
+
+class state_prep(NamedTuple):
+    ham_init: TKR[OpaqueType["__main__.Hamiltonian"]]  # noqa: F821 # fmt: skip
+    reference_state: TKR[list[int]]  # noqa: F821 # fmt: skip
+    max_iteration_prep: TKR[int]  # noqa: F821 # fmt: skip
+    atol: TKR[float]  # noqa: F821 # fmt: skip
+    mo_occ: TKR[list[int]]  # noqa: F821 # fmt: skip
+    cas_init: TKR[OpaqueType["__main__.CompleteActiveSpace"]]  # noqa: F821 # fmt: skip
+    cas_hsim: TKR[OpaqueType["__main__.CompleteActiveSpace"]]  # noqa: F821 # fmt: skip
+
+    @staticmethod
+    def out() -> type[TKR[OpaqueType["pytket._tket.circuit.Circuit"]]]:  # noqa: F821 # fmt: skip
+        return TKR[OpaqueType["pytket._tket.circuit.Circuit"]]  # noqa: F821 # fmt: skip
+
+    @property
+    def namespace(self) -> str:
+        return "qsci_worker"
+
+
+class circuits_from_hamiltonians(NamedTuple):
+    ham_init: TKR[OpaqueType["__main__.Hamiltonian"]]  # noqa: F821 # fmt: skip
+    ham_hsim: TKR[OpaqueType["__main__.Hamiltonian"]]  # noqa: F821 # fmt: skip
+    adapt_circuit: TKR[OpaqueType["pytket._tket.circuit.Circuit"]]  # noqa: F821 # fmt: skip
+    t_step_list: TKR[list[float]]  # noqa: F821 # fmt: skip
+    cas_init: TKR[OpaqueType["__main__.CompleteActiveSpace"]]  # noqa: F821 # fmt: skip
+    cas_hsim: TKR[OpaqueType["__main__.CompleteActiveSpace"]]  # noqa: F821 # fmt: skip
+    mo_occ: TKR[list[int]]  # noqa: F821 # fmt: skip
+    max_cx_gates: TKR[int]  # noqa: F821 # fmt: skip
+
+    @staticmethod
+    def out() -> type[TKR[list[OpaqueType["pytket._tket.circuit.Circuit"]]]]:  # noqa: F821 # fmt: skip
+        return TKR[list[OpaqueType["pytket._tket.circuit.Circuit"]]]  # noqa: F821 # fmt: skip
+
+    @property
+    def namespace(self) -> str:
+        return "qsci_worker"
+
+
+class energy_from_results(NamedTuple):
+    ham_hsim: TKR[OpaqueType["__main__.Hamiltonian"]]  # noqa: F821 # fmt: skip
+    backend_results: TKR[list[OpaqueType["pytket.backends.backendresult.BackendResult"]]]  # noqa: F821 # fmt: skip
+    mo_occ: TKR[list[int]]  # noqa: F821 # fmt: skip
+    cas_init: TKR[OpaqueType["__main__.CompleteActiveSpace"]]  # noqa: F821 # fmt: skip
+    cas_hsim: TKR[OpaqueType["__main__.CompleteActiveSpace"]]  # noqa: F821 # fmt: skip
+
+    @staticmethod
+    def out() -> type[TKR[float]]:  # noqa: F821 # fmt: skip
+        return TKR[float]  # noqa: F821 # fmt: skip
+
+    @property
+    def namespace(self) -> str:
+        return "qsci_worker"

--- a/examples/qsci_graph.py
+++ b/examples/qsci_graph.py
@@ -20,6 +20,8 @@ from tierkreis.controller.storage.filestorage import ControllerFileStorage
 
 from example_workers.chemistry_worker.stubs import (
     make_ham,
+    Molecule,
+    CompleteActiveSpace,
 )
 from example_workers.qsci_worker.stubs import (
     circuits_from_hamiltonians,
@@ -30,17 +32,6 @@ from example_workers.aer_worker.stubs import submit_single
 from example_workers.pytket_worker.stubs import compile_circuit_quantinuum
 
 root_loc = Loc()
-
-
-class Molecule(NamedTuple):
-    geometry: list[tuple[str, list[float]]]
-    basis: str
-    charge: int
-
-
-class CompleteActiveSpace(NamedTuple):
-    n: int
-    n_ele: int
 
 
 def _compile_and_run() -> GraphBuilder[

--- a/examples/qsci_graph.py
+++ b/examples/qsci_graph.py
@@ -69,7 +69,7 @@ class QSCIOutputs(NamedTuple):
 
 def qsci_graph() -> GraphBuilder[QSCIInputs, QSCIOutputs]:
     g = GraphBuilder(QSCIInputs, QSCIOutputs)
-    # Functions 'make_h_init'+'state_pre' and 'make_h_hsim' run in parallel
+    # Separate tasks 'make_h_init'+'state_pre' and 'make_h_hsim' run in parallel
     ham_init = g.task(make_ham(g.inputs.molecule, g.inputs.mo_occ, g.inputs.cas_init))
     ham_hsim = g.task(make_ham(g.inputs.molecule, g.inputs.mo_occ, g.inputs.cas_hsim))
 

--- a/examples/qsci_graph.py
+++ b/examples/qsci_graph.py
@@ -7,151 +7,116 @@
 # ///
 import json
 from pathlib import Path
+from typing import NamedTuple
 from uuid import UUID
 
+from tierkreis.builder import GraphBuilder
 from tierkreis.controller import run_graph
-from tierkreis.controller.data.graph import GraphData
 from tierkreis.controller.data.location import Loc
+from tierkreis.controller.data.models import TKR, OpaqueType
 from tierkreis.controller.executor.multiple import MultipleExecutor
 from tierkreis.controller.executor.uv_executor import UvExecutor
 from tierkreis.controller.storage.filestorage import ControllerFileStorage
 
+from example_workers.chemistry_worker.stubs import (
+    make_ham,
+)
+from example_workers.qsci_worker.stubs import (
+    circuits_from_hamiltonians,
+    energy_from_results,
+    state_prep,
+)
+from example_workers.aer_worker.stubs import submit_single
+from example_workers.pytket_worker.stubs import compile_circuit_quantinuum
+
 root_loc = Loc()
 
 
-def _compile_and_run() -> GraphData:
-    g = GraphData()
-    circuit = g.input("circuit")
+class Molecule(NamedTuple):
+    geometry: list[tuple[str, list[float]]]
+    basis: str
+    charge: int
+
+
+class CompleteActiveSpace(NamedTuple):
+    n: int
+    n_ele: int
+
+
+def _compile_and_run() -> GraphBuilder[
+    TKR[OpaqueType["pytket._tket.circuit.Circuit"]],  # noqa: F821
+    TKR[OpaqueType["pytket.backends.backendresult.BackendResult"]],  # noqa: F821
+]:
+    g = GraphBuilder(
+        TKR[OpaqueType["pytket._tket.circuit.Circuit"]],  # noqa: F821
+        TKR[OpaqueType["pytket.backends.backendresult.BackendResult"]],  # noqa: F821
+    )
+
     n_shots = g.const(500)
+    compiled_circuit = g.task(compile_circuit_quantinuum(g.inputs))
+    backend_result = g.task(submit_single(compiled_circuit, n_shots))
 
-    out = g.func("pytket_worker.compile_circuit_quantinuum", {"circuit": circuit})
-
-    backend_result = g.func(
-        "aer_worker.submit_single",
-        {"circuit": out("circuit"), "n_shots": n_shots},
-    )("backend_result")
-
-    g.output({"backend_result": backend_result})
+    g.outputs(backend_result)
     return g
 
 
-def qsci_graph() -> GraphData:
-    g = GraphData()
-    geometry = g.input("geometry")
-    basis = g.input("basis")
-    charge = g.input("charge")
-    mo_occ = g.input("mo_occ")
-    # init
-    n_cas_init = g.input("n_cas_init")
-    n_elecas_init = g.input("n_elecas_init")
-    # hsim
-    n_cas_hsim = g.input("n_cas_hsim")
-    n_elecas_hsim = g.input("n_elecas_hsim")
+class QSCIInputs(NamedTuple):
+    molecule: TKR[Molecule]
+    mo_occ: TKR[list[int]]  # TODO: check this type
+    reference_state: TKR[list[int]]  # TODO: check this type
+    cas_init: TKR[CompleteActiveSpace]
+    cas_hsim: TKR[CompleteActiveSpace]
+    t_step_list: TKR[list[float]]
+    max_iteration_prep: TKR[int]
+    max_cx_gates_hsim: TKR[int]
+    atol: TKR[float]
 
+
+class QSCIOutputs(NamedTuple):
+    energy: TKR[float]
+
+
+def qsci_graph() -> GraphBuilder[QSCIInputs, QSCIOutputs]:
+    g = GraphBuilder(QSCIInputs, QSCIOutputs)
     # Functions 'make_h_init'+'state_pre' and 'make_h_hsim' run in parallel
-    h_init = g.func(
-        "chemistry_worker.make_ham",
-        {
-            "geometry": geometry,
-            "basis": basis,
-            "charge": charge,
-            "mo_occ": mo_occ,
-            "n_cas": n_cas_init,
-            "n_elecas": n_elecas_init,
-        },
+    ham_init = g.task(make_ham(g.inputs.molecule, g.inputs.mo_occ, g.inputs.cas_init))
+    ham_hsim = g.task(make_ham(g.inputs.molecule, g.inputs.mo_occ, g.inputs.cas_hsim))
+
+    adapt_circuit = g.task(
+        state_prep(
+            ham_init,
+            g.inputs.reference_state,
+            g.inputs.max_iteration_prep,
+            g.inputs.atol,
+            g.inputs.mo_occ,
+            g.inputs.cas_init,
+            g.inputs.cas_hsim,
+        )
     )
-    h0_init = h_init("h0")
-    h1_init = h_init("h1")
-    h2_init = h_init("h2")
-
-    h_hsim = g.func(
-        "chemistry_worker.make_ham",
-        {
-            "geometry": geometry,
-            "basis": basis,
-            "charge": charge,
-            "mo_occ": mo_occ,
-            "n_cas": n_cas_hsim,
-            "n_elecas": n_elecas_hsim,
-        },
+    circuits = g.task(
+        circuits_from_hamiltonians(
+            ham_init,
+            ham_hsim,
+            adapt_circuit,
+            g.inputs.t_step_list,
+            g.inputs.cas_init,
+            g.inputs.cas_hsim,
+            g.inputs.mo_occ,
+            g.inputs.max_cx_gates_hsim,
+        )
     )
-    h0_hsim = h_hsim("h0")
-    h1_hsim = h_hsim("h1")
-    h2_hsim = h_hsim("h2")
-
-    reference_state = g.input("reference_state")
-    max_iteration_prep = g.input("max_iteration_prep")
-    atol = g.input("atol")
-
-    state_prep = g.func(
-        "qsci_worker.state_prep",
-        {
-            "h0_init": h0_init,
-            "h1_init": h1_init,
-            "h2_init": h2_init,
-            "reference_state": reference_state,
-            "max_iteration_prep": max_iteration_prep,
-            "atol": atol,
-            "mo_occ": mo_occ,
-            "n_cas_init": n_cas_init,
-            "n_elecas_init": n_elecas_init,
-            "n_cas_hsim": n_cas_hsim,
-            "n_elecas_hsim": n_elecas_hsim,
-        },
+    backend_results = g.map(_compile_and_run(), circuits)
+    energy = g.task(
+        energy_from_results(
+            ham_hsim,
+            backend_results,
+            g.inputs.mo_occ,
+            g.inputs.cas_init,
+            g.inputs.cas_hsim,
+        )
     )
-    adapt_circuit = state_prep("adapt_circuit")
 
-    t_step_list = g.input("t_step_list")
-    max_cx_gates_hsim = g.input("max_cx_gates_hsim")
-
-    circuits = g.func(
-        "qsci_worker.circuits_from_hamiltonians",
-        {
-            "h0_init": h0_init,
-            "h1_init": h1_init,
-            "h2_init": h2_init,
-            "h0_hsim": h0_hsim,
-            "h1_hsim": h1_hsim,
-            "h2_hsim": h2_hsim,
-            "adapt_circuit": adapt_circuit,
-            "t_step_list": t_step_list,
-            "n_elecas_init": n_elecas_init,
-            "n_elecas_hsim": n_elecas_hsim,
-            "n_cas_hsim": n_cas_hsim,
-            "mo_occ": mo_occ,
-            "max_cx_gates": max_cx_gates_hsim,
-        },
-    )("circuits")
-
-    unfolded_circuits = g.func("builtins.unfold_values", {"value": circuits})
-
-    compile_and_run_const = g.const(_compile_and_run())
-    m = g.map(
-        compile_and_run_const,
-        unfolded_circuits("*")[0],
-        "circuit",
-        "backend_result",
-        {},
-    )
-    backend_results = g.func("builtins.fold_values", {"values_glob": m("*")})("value")
-
-    energy = g.func(
-        "qsci_worker.energy_from_results",
-        {
-            "h0_hsim": h0_hsim,
-            "h1_hsim": h1_hsim,
-            "h2_hsim": h2_hsim,
-            "backend_results": backend_results,
-            "mo_occ": mo_occ,
-            "n_elecas_init": n_elecas_init,
-            "n_elecas_hsim": n_elecas_hsim,
-            "n_cas_init": n_cas_init,
-            "n_cas_hsim": n_cas_hsim,
-        },
-    )("energy")
-
-    g.output({"energy": energy})
-
+    g.outputs(QSCIOutputs(energy))
     return g
 
 
@@ -182,26 +147,32 @@ def main() -> None:
     run_graph(
         storage,
         multi_executor,
-        qsci_graph(),
+        qsci_graph().get_data(),
         {
             k: json.dumps(v).encode()
             for k, v in (
                 {
-                    "basis": "sto-3g",
-                    "charge": 0,
-                    "geometry": [
-                        ["H", [0, 0, 0]],
-                        ["H", [0, 0, 1.0]],
-                        ["H", [0, 0, 2.0]],
-                        ["H", [0, 0, 3.0]],
-                    ],
+                    "molecule": {
+                        "geometry": [
+                            ["H", [0, 0, 0]],
+                            ["H", [0, 0, 1.0]],
+                            ["H", [0, 0, 2.0]],
+                            ["H", [0, 0, 3.0]],
+                        ],
+                        "basis": "sto-3g",
+                        "charge": 0,
+                    },
+                    "reference_state": [1, 1, 0, 0],
+                    "cas_init": {
+                        "n": 2,
+                        "n_ele": 2,
+                    },
+                    "cas_hsim": {
+                        "n": 4,
+                        "n_ele": 4,
+                    },
                     "max_cx_gates_hsim": 2000,
                     "mo_occ": [2, 2, 0, 0],
-                    "reference_state": [1, 1, 0, 0],
-                    "n_cas_init": 2,
-                    "n_elecas_init": 2,
-                    "n_cas_hsim": 4,
-                    "n_elecas_hsim": 4,
                     "t_step_list": [0.5, 1.0, 1.5],
                     "max_iteration_prep": 5,
                     "atol": 0.03,

--- a/justfile
+++ b/justfile
@@ -44,9 +44,9 @@ examples:
 stubs-generate dir:
   #!/usr/bin/env bash
   cd {{dir}}
-  uv run main.py --stubs-path ./stubs.py
-  uv run ruff format stubs.py
-  uv run ruff check --fix stubs.py
+  python main.py --stubs-path ./stubs.py
+  ruff format stubs.py
+  ruff check --fix stubs.py
 
 generate: 
   just stubs-generate 'tierkreis/tierkreis/builtins'

--- a/justfile
+++ b/justfile
@@ -44,9 +44,9 @@ examples:
 stubs-generate dir:
   #!/usr/bin/env bash
   cd {{dir}}
-  python main.py --stubs-path ./stubs.py
-  ruff format stubs.py
-  ruff check --fix stubs.py
+  uv run main.py --stubs-path ./stubs.py
+  uv run ruff format stubs.py
+  uv run ruff check --fix stubs.py
 
 generate: 
   just stubs-generate 'tierkreis/tierkreis/builtins'

--- a/justfile
+++ b/justfile
@@ -56,6 +56,8 @@ generate:
   just stubs-generate 'examples/example_workers/error_worker'
   just stubs-generate 'examples/example_workers/hello_world_worker'
   just stubs-generate 'examples/example_workers/substitution_worker'
+  just stubs-generate 'examples/example_workers/chemistry_worker'
+  just stubs-generate 'examples/example_workers/qsci_worker'
 
   mkdir -p examples/example_workers/aer_worker
   mkdir -p examples/example_workers/nexus_worker

--- a/tierkreis/tests/controller/test_models.py
+++ b/tierkreis/tests/controller/test_models.py
@@ -1,11 +1,12 @@
 from types import NoneType
 from typing import NamedTuple
 import pytest
-from tierkreis.controller.data.models import PModel, dict_from_pmodel
+from tierkreis.controller.data.models import PModel, dict_from_pmodel, portmapping
 from tierkreis.controller.data.types import PType
 from tests.controller.test_types import ptypes
 
 
+@portmapping
 class NamedPModel(NamedTuple):
     a: bool
     b: int

--- a/tierkreis/tierkreis/codegen.py
+++ b/tierkreis/tierkreis/codegen.py
@@ -1,4 +1,3 @@
-from inspect import isclass
 from types import NoneType
 from typing import assert_never, get_args, get_origin
 from pydantic import BaseModel

--- a/tierkreis/tierkreis/codegen.py
+++ b/tierkreis/tierkreis/codegen.py
@@ -85,28 +85,28 @@ def format_output(outputs: type[PModel]) -> str:
     return f"TKR[{format_ptype(outputs)}]"
 
 
-def format_input_pnamedmodel(pnamedmodel: type[PNamedModel]) -> str:
-    origin = get_origin(pnamedmodel)
-    args = get_args(pnamedmodel)
+def format_input_pnamedmodel(model: type[PNamedModel]) -> str:
+    origin = get_origin(model)
+    args = get_args(model)
     if origin is not None:
-        pnamedmodel = origin
+        model = origin
 
-    outs = {
-        format_protocol_attribute(k, v) for k, v in pnamedmodel.__annotations__.items()
-    }
+    outs = [format_protocol_attribute(k, v) for k, v in model.__annotations__.items()]
+    outs.sort()
     outs_str = "\n    ".join(outs)
 
     generics = [str(x) for x in args]
     generics_str = f", Generic[{', '.join(generics)}]" if generics else ""
 
     return f"""
-class {pnamedmodel.__qualname__}(Struct, Protocol{generics_str}):
+class {model.__qualname__}(Struct, Protocol{generics_str}):
     {outs_str}
 """
 
 
 def format_input_pnamedmodels(models: set[type[PNamedModel]]) -> str:
-    return "\n\n".join([format_input_pnamedmodel(x) for x in models])
+    ms = sorted(list(models), key=lambda x: x.__name__)
+    return "\n\n".join([format_input_pnamedmodel(x) for x in ms])
 
 
 def format_function(namespace_name: str, fn: FunctionSpec) -> str:

--- a/tierkreis/tierkreis/codegen.py
+++ b/tierkreis/tierkreis/codegen.py
@@ -40,10 +40,7 @@ def format_ptype(ptype: type[PType]) -> str:
         args = [format_ptype(x) for x in get_args(ptype)]
         return f"dict[{', '.join(args)}]"
 
-    if issubclass(ptype, (bool, int, float, str, bytes, NoneType)):
-        return ptype.__qualname__
-
-    if issubclass(ptype, Struct):
+    if issubclass(ptype, (bool, int, float, str, bytes, NoneType, Struct)):
         return ptype.__qualname__
 
     if issubclass(ptype, (DictConvertible, ListConvertible, BaseModel)):

--- a/tierkreis/tierkreis/codegen.py
+++ b/tierkreis/tierkreis/codegen.py
@@ -78,13 +78,6 @@ def format_annotation(
     return f"{port_id}{sep} TKR[{format_ptype(ptype)}]{constructor} {NO_QA_STR}"
 
 
-def format_output(outputs: type[PModel]) -> str:
-    if isclass(outputs) and is_portmapping(outputs):
-        return outputs.__qualname__
-
-    return f"TKR[{format_ptype(outputs)}]"
-
-
 def format_input_pnamedmodel(model: type[PNamedModel]) -> str:
     origin = get_origin(model)
     args = get_args(model)

--- a/tierkreis/tierkreis/codegen.py
+++ b/tierkreis/tierkreis/codegen.py
@@ -8,12 +8,12 @@ from tierkreis.controller.data.types import (
     DictConvertible,
     ListConvertible,
     PType,
+    Struct,
     _is_generic,
     _is_list,
     _is_mapping,
     _is_tuple,
     _is_union,
-    is_named_tuple,
 )
 from tierkreis.namespace import FunctionSpec, Namespace
 
@@ -43,7 +43,7 @@ def format_ptype(ptype: type[PType]) -> str:
     if issubclass(ptype, (bool, int, float, str, bytes, NoneType)):
         return ptype.__qualname__
 
-    if is_named_tuple(ptype):
+    if issubclass(ptype, Struct):
         return ptype.__qualname__
 
     if issubclass(ptype, (DictConvertible, ListConvertible, BaseModel)):
@@ -82,13 +82,14 @@ def format_annotation(
 
 
 def format_output(outputs: type[PModel]) -> str:
-    if isclass(outputs) and issubclass(outputs, PNamedModel):
+    if isclass(outputs) and is_portmapping(outputs):
         return outputs.__qualname__
 
     return f"TKR[{format_ptype(outputs)}]"
 
 
 def format_input_pnamedmodel(pnamedmodel: type[PNamedModel]) -> str:
+    print(pnamedmodel)
     origin = get_origin(pnamedmodel)
     args = get_args(pnamedmodel)
     if origin is not None:
@@ -103,7 +104,7 @@ def format_input_pnamedmodel(pnamedmodel: type[PNamedModel]) -> str:
     generics_str = f", Generic[{', '.join(generics)}]" if generics else ""
 
     return f"""
-class {pnamedmodel.__qualname__}(Protocol{generics_str}):
+class {pnamedmodel.__qualname__}(PNamedModel, Protocol{generics_str}):
     {outs_str}
 """
 
@@ -170,7 +171,7 @@ def format_namespace(namespace: Namespace) -> str:
 
 from typing import Literal, NamedTuple, Sequence, TypeVar, Generic, Protocol
 from types import NoneType
-from tierkreis.controller.data.models import TKR, OpaqueType
+from tierkreis.controller.data.models import TKR, OpaqueType, PNamedModel
 from tierkreis.controller.data.types import PType
 
 {format_typevars(namespace.generics)}

--- a/tierkreis/tierkreis/codegen.py
+++ b/tierkreis/tierkreis/codegen.py
@@ -89,7 +89,6 @@ def format_output(outputs: type[PModel]) -> str:
 
 
 def format_input_pnamedmodel(pnamedmodel: type[PNamedModel]) -> str:
-    print(pnamedmodel)
     origin = get_origin(pnamedmodel)
     args = get_args(pnamedmodel)
     if origin is not None:
@@ -104,7 +103,7 @@ def format_input_pnamedmodel(pnamedmodel: type[PNamedModel]) -> str:
     generics_str = f", Generic[{', '.join(generics)}]" if generics else ""
 
     return f"""
-class {pnamedmodel.__qualname__}(PNamedModel, Protocol{generics_str}):
+class {pnamedmodel.__qualname__}(Struct, Protocol{generics_str}):
     {outs_str}
 """
 
@@ -171,8 +170,8 @@ def format_namespace(namespace: Namespace) -> str:
 
 from typing import Literal, NamedTuple, Sequence, TypeVar, Generic, Protocol
 from types import NoneType
-from tierkreis.controller.data.models import TKR, OpaqueType, PNamedModel
-from tierkreis.controller.data.types import PType
+from tierkreis.controller.data.models import TKR, OpaqueType
+from tierkreis.controller.data.types import PType, Struct
 
 {format_typevars(namespace.generics)}
 

--- a/tierkreis/tierkreis/codegen.py
+++ b/tierkreis/tierkreis/codegen.py
@@ -67,7 +67,7 @@ def format_annotation(port_id: PortID, ptype: type[PType], is_raw: bool = False)
 
 
 def format_model(
-    model: type[PNamedModel], bases: list[str], is_raw: bool = False
+    model: type[PNamedModel] | type[Struct], bases: list[str], is_raw: bool = False
 ) -> str:
     origin = get_origin(model)
     args = get_args(model)
@@ -116,7 +116,7 @@ def format_typevars(generics: set[str]) -> str:
     return "\n".join([format_typevar(x) for x in sorted(list(generics))])
 
 
-def format_input_models(models: set[type[PNamedModel]]) -> str:
+def format_input_models(models: set[type[Struct]]) -> str:
     ms = sorted(list(models), key=lambda x: x.__name__)
     return "\n\n".join([format_model(x, ["Struct", "Protocol"], True) for x in ms])
 
@@ -141,7 +141,7 @@ from tierkreis.controller.data.types import PType, Struct
 
 {format_typevars(namespace.generics)}
 
-{format_input_models(namespace.input_models)}
+{format_input_models(namespace.structs)}
 
 {format_output_models(namespace.output_models)}
 

--- a/tierkreis/tierkreis/controller/data/core.py
+++ b/tierkreis/tierkreis/controller/data/core.py
@@ -1,4 +1,4 @@
-from typing import NamedTuple
+from typing import NamedTuple, Protocol, SupportsIndex, runtime_checkable
 
 
 PortID = str
@@ -7,3 +7,11 @@ ValueRef = tuple[NodeIndex, PortID]
 
 
 class EmptyModel(NamedTuple): ...
+
+
+@runtime_checkable
+class RestrictedNamedTuple[T](Protocol):
+    """A NamedTuple whose members are restricted to being of type T."""
+
+    def _asdict(self) -> dict[str, T]: ...
+    def __getitem__(self, key: SupportsIndex, /) -> T: ...

--- a/tierkreis/tierkreis/controller/data/models.py
+++ b/tierkreis/tierkreis/controller/data/models.py
@@ -74,13 +74,6 @@ def is_portmapping(
     return hasattr(o, TKR_PORTMAPPING_FLAG)
 
 
-def is_pnamedmodel(o) -> TypeIs[type[PNamedModel]]:
-    origin = get_origin(o)
-    if origin is not None:
-        return is_pnamedmodel(origin)
-    return isclass(o) and issubclass(o, PNamedModel)
-
-
 def is_tnamedmodel(o) -> TypeIs[type[TNamedModel]]:
     origin = get_origin(o)
     if origin is not None:

--- a/tierkreis/tierkreis/controller/data/models.py
+++ b/tierkreis/tierkreis/controller/data/models.py
@@ -4,28 +4,29 @@ from itertools import chain
 from typing import (
     Literal,
     Protocol,
-    SupportsIndex,
     cast,
     dataclass_transform,
     get_origin,
     runtime_checkable,
 )
 from typing_extensions import TypeIs
-from tierkreis.controller.data.core import NodeIndex, PortID, ValueRef
+from tierkreis.controller.data.core import (
+    NodeIndex,
+    PortID,
+    RestrictedNamedTuple,
+    ValueRef,
+)
 from tierkreis.controller.data.types import PType, generics_in_ptype
 
 TKR_PORTMAPPING_FLAG = "__tkr_portmapping__"
 
 
 @runtime_checkable
-class PNamedModel(Protocol):
+class PNamedModel(RestrictedNamedTuple[PType], Protocol):
     """A struct whose members are restricted to being PTypes.
 
     E.g. used to specify multiple outputs in Python worker code.
     """
-
-    def _asdict(self) -> dict[str, PType]: ...
-    def __getitem__(self, key: SupportsIndex, /) -> PType: ...
 
 
 @dataclass_transform()
@@ -48,13 +49,10 @@ class TKR[T: PModel]:
 
 
 @runtime_checkable
-class TNamedModel(Protocol):
+class TNamedModel(RestrictedNamedTuple[TKR[PType]], Protocol):
     """A struct whose members are restricted to being references to PTypes.
 
     E.g. in graph builder code these are outputs of tasks."""
-
-    def _asdict(self) -> dict[str, TKR[PType]]: ...
-    def __getitem__(self, key: SupportsIndex, /) -> TKR[PType]: ...
 
 
 TModel = TNamedModel | TKR

--- a/tierkreis/tierkreis/controller/data/models.py
+++ b/tierkreis/tierkreis/controller/data/models.py
@@ -64,10 +64,17 @@ def is_portmapping(o: PModel) -> TypeIs[PNamedModel]: ...
 @overload
 def is_portmapping(o: type[PModel]) -> TypeIs[type[PNamedModel]]: ...
 @overload
+def is_portmapping(o: TModel) -> TypeIs[TNamedModel]: ...
+@overload
 def is_portmapping(o: type[TModel]) -> TypeIs[type[TNamedModel]]: ...
 def is_portmapping(
     o,
-) -> TypeIs[type[PNamedModel]] | TypeIs[PNamedModel] | TypeIs[type[TNamedModel]]:
+) -> (
+    TypeIs[type[PNamedModel]]
+    | TypeIs[PNamedModel]
+    | TypeIs[TNamedModel]
+    | TypeIs[type[TNamedModel]]
+):
     origin = get_origin(o)
     if origin is not None:
         return is_portmapping(origin)

--- a/tierkreis/tierkreis/controller/data/models.py
+++ b/tierkreis/tierkreis/controller/data/models.py
@@ -77,7 +77,7 @@ def is_portmapping(
 def is_pnamedmodel(o) -> TypeIs[type[PNamedModel]]:
     origin = get_origin(o)
     if origin is not None:
-        return is_tnamedmodel(origin)
+        return is_pnamedmodel(origin)
     return isclass(o) and issubclass(o, PNamedModel)
 
 

--- a/tierkreis/tierkreis/controller/data/types.py
+++ b/tierkreis/tierkreis/controller/data/types.py
@@ -22,6 +22,7 @@ from typing import (
 
 from pydantic import BaseModel
 from pydantic._internal._generics import get_args as pydantic_get_args
+from tierkreis.controller.data.core import RestrictedNamedTuple
 from typing_extensions import TypeIs
 
 
@@ -39,7 +40,7 @@ class ListConvertible(Protocol):
     def from_list(cls, arg: list, /) -> "Self": ...
 
 
-type PType = (
+type _PType = (
     bool
     | int
     | float
@@ -56,6 +57,13 @@ type PType = (
     | NamedTuple
     | BaseModel
 )
+
+
+@runtime_checkable
+class Struct(RestrictedNamedTuple[_PType], Protocol): ...
+
+
+PType = _PType | Struct
 """A restricted subset of Python types that can be used to annotate
 worker functions for automatic codegen of graph builder stubs."""
 
@@ -130,11 +138,11 @@ def is_ptype(annotation: Any) -> TypeIs[type[PType]]:
         return True
 
     elif isclass(annotation) and issubclass(
-        annotation, (DictConvertible, ListConvertible, BaseModel)
+        annotation, (DictConvertible, ListConvertible, BaseModel, Struct)
     ):
         return True
 
-    elif annotation in get_args(PType.__value__):
+    elif annotation in get_args(_PType.__value__):
         return True
 
     else:
@@ -158,6 +166,8 @@ def ser_from_ptype(ptype: PType) -> Any | bytes:
             return ser_from_ptype(ptype.to_list())
         case BaseModel():
             return ptype.model_dump(mode="json")
+        case Struct():
+            return {k: ser_from_ptype(p) for k, p in ptype._asdict().items()}
         case _:
             assert_never(ptype)
 
@@ -213,6 +223,9 @@ def coerce_from_annotation[T: PType](ser: Any, annotation: type[T]) -> T:
 
         return cast(T, {k: coerce_from_annotation(v, args[1]) for k, v in ser.items()})
 
+    if issubclass(origin, Struct):
+        return cast(T, origin(**ser))
+
     assert_never(ser)
 
 
@@ -241,7 +254,7 @@ def generics_in_ptype(ptype: type[PType]) -> set[str]:
     if issubclass(ptype, (bool, int, float, str, bytes, NoneType)):
         return set()
 
-    if issubclass(ptype, (DictConvertible, ListConvertible)):
+    if issubclass(ptype, (DictConvertible, ListConvertible, Struct)):
         return set()
 
     if is_named_tuple(ptype):

--- a/tierkreis/tierkreis/controller/data/types.py
+++ b/tierkreis/tierkreis/controller/data/types.py
@@ -110,16 +110,6 @@ def _is_tuple(o: object) -> TypeIs[type[tuple[Any, ...]]]:
     return get_origin(o) is tuple
 
 
-def is_named_tuple(o: object) -> TypeIs[type[tuple]]:
-    if not isclass(o):
-        return False
-    # If it looks like a NamedTuple it is probably a NamedTuple
-    # (no way to check if it actually is in Python currently).
-    if issubclass(o, tuple) and hasattr(o, "_asdict") and hasattr(o, "_fields"):
-        return True
-    return False
-
-
 def is_ptype(annotation: Any) -> TypeIs[type[PType]]:
     if _is_generic(annotation):
         return True
@@ -131,9 +121,6 @@ def is_ptype(annotation: Any) -> TypeIs[type[PType]]:
         or _is_mapping(annotation)
     ):
         return all(is_ptype(x) for x in get_args(annotation))
-
-    elif is_named_tuple(annotation):
-        return True
 
     elif isclass(annotation) and issubclass(
         annotation, (DictConvertible, ListConvertible, BaseModel, Struct)
@@ -253,9 +240,6 @@ def generics_in_ptype(ptype: type[PType]) -> set[str]:
         return set()
 
     if issubclass(ptype, (DictConvertible, ListConvertible, Struct)):
-        return set()
-
-    if is_named_tuple(ptype):
         return set()
 
     if issubclass(ptype, BaseModel):

--- a/tierkreis/tierkreis/controller/data/types.py
+++ b/tierkreis/tierkreis/controller/data/types.py
@@ -208,11 +208,6 @@ def coerce_from_annotation[T: PType](ser: Any, annotation: type[T]) -> T:
         return annotation(**ser)
 
     if issubclass(origin, Struct):
-        import logging
-
-        logger = logging.getLogger(__name__)
-        logger.error(origin)
-        logger.error(ser)
         return cast(T, origin(**ser))
 
     if issubclass(origin, collections.abc.Sequence):

--- a/tierkreis/tierkreis/namespace.py
+++ b/tierkreis/tierkreis/namespace.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass, field
+from inspect import get_annotations
 from logging import getLogger
 from types import NoneType
 from typing import Any, Callable
@@ -49,7 +50,18 @@ class Namespace:
     name: str
     functions: dict[str, FunctionSpec] = field(default_factory=lambda: {})
     generics: set[str] = field(default_factory=lambda: set())
-    refs: set[type[PNamedModel]] = field(default_factory=lambda: set())
+    input_models: set[type[PNamedModel]] = field(default_factory=lambda: set())
+    output_models: set[type[PNamedModel]] = field(default_factory=lambda: set())
+
+    def _add_input_model(self, annotation: Any) -> None:
+        if is_portmapping(annotation):
+            sub_annotations = get_annotations(annotation)
+            [
+                self._add_input_model(sub_annotation)
+                for sub_annotation in sub_annotations
+            ]
+
+            self.input_models.add(annotation)
 
     def add_from_annotations(self, func: WorkerFunction) -> None:
         name = func.__name__
@@ -59,9 +71,14 @@ class Namespace:
             fn = FunctionSpec(
                 name=name, namespace=self.name, ins={}, outs=NoneType, generics=generics
             )
-            [self.refs.add(v) for k, v in annotations.items() if is_portmapping(v)]
+
+            [self._add_input_model(v) for k, v in annotations.items() if k != "return"]
             fn.add_inputs({k: v for k, v in annotations.items() if k != "return"})
+
+            if is_portmapping(annotations["return"]):
+                self.output_models.add(annotations["return"])
             fn.add_outputs(annotations["return"])
+
             self.functions[fn.name] = fn
             self.generics.update(fn.generics)
         except TierkreisError as exc:

--- a/tierkreis/tierkreis/namespace.py
+++ b/tierkreis/tierkreis/namespace.py
@@ -78,6 +78,8 @@ class Namespace:
 
             if is_portmapping(annotations["return"]):
                 self.output_models.add(annotations["return"])
+            elif is_pnamedmodel(annotations["return"]):
+                self.input_models.add(annotations["return"])
             fn.add_outputs(annotations["return"])
 
             self.functions[fn.name] = fn

--- a/tierkreis/tierkreis/namespace.py
+++ b/tierkreis/tierkreis/namespace.py
@@ -6,6 +6,7 @@ from typing import Any, Callable
 from tierkreis.controller.data.models import (
     PModel,
     PNamedModel,
+    is_pnamedmodel,
     is_portmapping,
 )
 from tierkreis.controller.data.types import PType, is_ptype
@@ -54,7 +55,7 @@ class Namespace:
     output_models: set[type[PNamedModel]] = field(default_factory=lambda: set())
 
     def _add_input_model(self, annotation: Any) -> None:
-        if is_portmapping(annotation):
+        if is_pnamedmodel(annotation):
             sub_annotations = get_annotations(annotation)
             [
                 self._add_input_model(sub_annotation)

--- a/tierkreis/tierkreis/worker/worker.py
+++ b/tierkreis/tierkreis/worker/worker.py
@@ -78,7 +78,7 @@ class Worker:
 
         def function_decorator(func: WorkerFunction) -> None:
             func_name = func.__name__
-            self.namespace.add_from_annotations(func)
+            self.namespace.add_function(func)
 
             def wrapper(node_definition: WorkerCallArgs):
                 kwargs = self._load_args(func, node_definition.inputs)


### PR DESCRIPTION
A combination of various other branches.

* Add `Struct` to `PType`.
* Codegen: generate Protocols for every `Struct` we find as inputs or outputs of a worker task.
* Update the qsci_graph to use the typed graph builder. Add `chemistry_worker` and `qsci_worker` to stubs generation in justfile.
* Define `RestrictedNamedTuple` that is a NamedTuple whose members are restricted to being of type T.