### PR TITLE
Feat: graphdata visualizer

### DIFF
--- a/justfile
+++ b/justfile
@@ -26,7 +26,7 @@ docs:
 
 [working-directory:'tierkreis_visualization']
 serve:
-	{{uvrun}} fastapi dev tierkreis_visualization/main.py
+	{{uvrun}} python tierkreis_visualization/main.py
 
 [working-directory:'tierkreis_visualization']
 prod:

--- a/tierkreis/tierkreis/controller/storage/filestorage.py
+++ b/tierkreis/tierkreis/controller/storage/filestorage.py
@@ -1,6 +1,7 @@
 import json
 import os
 import shutil
+from datetime import datetime
 from pathlib import Path
 from time import time_ns
 from typing import Any
@@ -184,7 +185,7 @@ class ControllerFileStorage:
 
     def write_metadata(self, node_location: Loc) -> None:
         with open(self._metadata_path(node_location), "w+") as fh:
-            fh.write(json.dumps({"name": self.name}))
+            fh.write(json.dumps({"name": self.name, "start": str(datetime.now())}))
 
     def read_metadata(self, node_location: Loc) -> dict[str, Any]:
         with open(self._metadata_path(node_location)) as fh:

--- a/tierkreis/tierkreis/controller/storage/graphdata.py
+++ b/tierkreis/tierkreis/controller/storage/graphdata.py
@@ -15,15 +15,6 @@ from tierkreis.controller.data.location import (
 from tierkreis.exceptions import TierkreisError
 from tierkreis.controller.storage.in_memory import NodeData
 
-# class NodeData(BaseModel):
-#     definition: NodeDef | None = None
-#     call_args: WorkerCallArgs | None = None
-#     is_done: bool = False
-#     has_error: bool = False
-#     metadata: dict[str, Any] = Field(default_factory=dict)
-#     error_logs: str = ""
-#     outputs: dict[PortID, bytes | None] = Field(default_factory=dict)
-
 
 class GraphDataStorage:
     def __init__(
@@ -99,15 +90,12 @@ class GraphDataStorage:
         if output_name in node.outputs:
             if output := node.outputs[output_name]:
                 return output
-            return b""
+            return b"null"
         raise TierkreisError(f"No output named {output_name} in node {node_location}")
 
     def read_output_ports(self, node_location: Loc) -> list[PortID]:
         node = self._node_from_loc(node_location)
-        return list(
-            # node.outputs.keys()
-            filter(lambda k: k != "*", node.outputs.keys())
-        )
+        return list(filter(lambda k: k != "*", node.outputs.keys()))
 
     def is_node_started(self, node_location: Loc) -> bool:
         return False

--- a/tierkreis/tierkreis/controller/storage/graphdata.py
+++ b/tierkreis/tierkreis/controller/storage/graphdata.py
@@ -5,8 +5,8 @@ from typing import Any, assert_never
 from datetime import datetime
 
 
-from tierkreis.controller.data.core import PortID, ValueRef
-from tierkreis.controller.data.graph import Const, Eval, GraphData, NodeDef
+from tierkreis.controller.data.core import PortID
+from tierkreis.controller.data.graph import Eval, GraphData, NodeDef
 from tierkreis.controller.data.location import (
     Loc,
     OutputLoc,
@@ -250,87 +250,3 @@ class GraphDataStorage:
             )
 
         return self.nodes[node_location]
-
-    def _evaluate_symbolic(self, graph: GraphData, parent_loc: Loc = Loc()) -> None:
-        unfinished_inputs = [((graph.output_idx(), ""), parent_loc)]
-        for input, parent in unfinished_inputs:
-            output_id = input[0]
-            output_node = graph.nodes[output_id]
-            outputs = list(graph.node_outputs[output_id])
-            loc = parent.N(output_id)
-            if "*" in outputs:
-                outputs.append("0")
-            self.nodes[loc] = NodeData(
-                definition=output_node,
-                call_args=None,
-                is_done=False,
-                has_error=False,
-                metadata={},
-                error_logs="",
-                outputs={output: None for output in outputs},
-            )
-            new_unfinished_inputs = self._in_edges(output_node, output_id, parent)
-            unfinished_inputs += new_unfinished_inputs
-
-    def _in_edges(
-        self, node: NodeDef, node_id: int, parent: Loc
-    ) -> list[tuple[ValueRef, Loc]]:
-        """Mimics tierkreis.controller.storage.adjacency.in_edges.
-        This lets us know which nodes are the inputs of the current node.
-        """
-        parents = [(x, parent) for x in node.inputs.values()]
-        node_loc = parent.N(node_id)
-        match node.type:
-            case "eval":
-                parents.append((node.graph, node_loc))
-            case "loop":
-                parents.append((node.body, node_loc))
-            case "map":
-                # Unevaluated maps have a body but no child element to evaluate it
-                # We add the first child "0" to allow visualization of the body
-                self.nodes[node_loc.M("0")] = NodeData(
-                    definition=Eval((-1, "body"), {})
-                )
-                parents.append((node.body, node_loc))
-            case "ifelse" | "eifelse":
-                # We want to see conditional branches in both cases
-                parents.append((node.pred, node_loc))
-                parents.append((node.if_true, node_loc))
-                parents.append((node.if_false, node_loc))
-            case "const":
-                # Const nodes can be graphs themselves, so we need to handle them
-                self._handle_const(node, node_id, parent)
-            case "function" | "input" | "output":
-                pass
-            case _:
-                assert_never(node)
-
-        return parents
-
-    def _handle_const(self, node: Const, node_id: int, parent: Loc) -> None:
-        if parent.parent() is None:
-            raise TierkreisError(
-                f"Node {node_id} with value {node.value} cannot be a graph output without a parent."
-            )
-        value: GraphData | None = None
-        # Try to load a nested graph from value
-        if isinstance(node.value, GraphData):
-            value = node.value
-        elif isinstance(node.value, dict):
-            try:
-                value = GraphData(**node.value)
-            except TypeError:
-                raise TierkreisError(f"Cannot convert {node}s value to GraphData.")
-        if value is None:
-            # not a graph
-            return
-
-        self.nodes[parent.parent().N(node_id)] = NodeData(  # type: ignore
-            definition=Const(value),
-            outputs={"value": value.model_dump_json().encode()},
-        )
-
-        if parent.M("0") in self.nodes:
-            # This is a map node
-            parent = parent.M("0")
-        self.evaluate_symbolic(value, parent)

--- a/tierkreis/tierkreis/controller/storage/graphdata.py
+++ b/tierkreis/tierkreis/controller/storage/graphdata.py
@@ -1,0 +1,336 @@
+from collections import defaultdict
+from pathlib import Path
+from uuid import UUID
+from typing import Any, assert_never
+from datetime import datetime
+
+
+from tierkreis.controller.data.core import PortID, ValueRef
+from tierkreis.controller.data.graph import Const, Eval, GraphData, NodeDef
+from tierkreis.controller.data.location import (
+    Loc,
+    OutputLoc,
+    WorkerCallArgs,
+)
+from tierkreis.exceptions import TierkreisError
+from tierkreis.controller.storage.in_memory import NodeData
+
+# class NodeData(BaseModel):
+#     definition: NodeDef | None = None
+#     call_args: WorkerCallArgs | None = None
+#     is_done: bool = False
+#     has_error: bool = False
+#     metadata: dict[str, Any] = Field(default_factory=dict)
+#     error_logs: str = ""
+#     outputs: dict[PortID, bytes | None] = Field(default_factory=dict)
+
+
+class GraphDataStorage:
+    def __init__(
+        self,
+        workflow_id: UUID,
+        graph: GraphData,
+        name: str | None = None,
+    ) -> None:
+        self.workflow_id = workflow_id
+        self.name = name
+        self.nodes: dict[Loc, NodeData] = defaultdict(lambda: NodeData())
+        self.graph = graph
+        self._initialize_storage(graph)
+        self.logs_path = Path("")
+
+    def write_node_def(self, node_location: Loc, node: NodeDef) -> None:
+        raise NotImplementedError("GraphDataStorage is read only storage.")
+
+    def read_node_def(self, node_location: Loc) -> NodeDef:
+        node = self._node_from_loc(node_location)
+        if result := node.definition:
+            return result
+        raise TierkreisError(f"Node definition of {node_location} not found.")
+
+    def write_worker_call_args(
+        self,
+        node_location: Loc,
+        function_name: str,
+        inputs: dict[PortID, OutputLoc],
+        output_list: list[PortID],
+    ) -> Path:
+        raise NotImplementedError("GraphDataStorage is read only storage.")
+
+    def read_worker_call_args(self, node_location: Loc) -> WorkerCallArgs:
+        node = self._node_from_loc(node_location)
+        if result := node.call_args:
+            return result
+        raise TierkreisError(
+            f"Node location {node_location} doesn't have a associate call args."
+        )
+
+    def read_errors(self, node_location: Loc) -> str:
+        return ""
+
+    def node_has_error(self, node_location: Loc) -> bool:
+        return False
+
+    def write_node_errors(self, node_location: Loc, error_logs: str) -> None:
+        raise NotImplementedError("GraphDataStorage is read only storage.")
+
+    def mark_node_finished(self, node_location: Loc) -> None:
+        raise NotImplementedError("GraphDataStorage is read only storage.")
+
+    def is_node_finished(self, node_location: Loc) -> bool:
+        return False
+
+    def link_outputs(
+        self,
+        new_location: Loc,
+        new_port: PortID,
+        old_location: Loc,
+        old_port: PortID,
+    ) -> None:
+        raise NotImplementedError("GraphDataStorage is read only storage.")
+
+    def write_output(
+        self, node_location: Loc, output_name: PortID, value: bytes
+    ) -> Path:
+        raise NotImplementedError("GraphDataStorage is read only storage.")
+
+    def read_output(self, node_location: Loc, output_name: PortID) -> bytes:
+        node = self._node_from_loc(node_location)
+        if output_name in node.outputs:
+            if output := node.outputs[output_name]:
+                return output
+            return b""
+        raise TierkreisError(f"No output named {output_name} in node {node_location}")
+
+    def read_output_ports(self, node_location: Loc) -> list[PortID]:
+        node = self._node_from_loc(node_location)
+        return list(
+            # node.outputs.keys()
+            filter(lambda k: k != "*", node.outputs.keys())
+        )
+
+    def is_node_started(self, node_location: Loc) -> bool:
+        return False
+
+    def read_metadata(self, node_location: Loc) -> dict[str, Any]:
+        return self.nodes[node_location].metadata
+
+    def write_metadata(self, node_location: Loc) -> None:
+        raise NotImplementedError("GraphDataStorage is read only storage.")
+
+    def _initialize_storage(self, graph: GraphData, parent_loc: Loc = Loc()) -> None:
+        """Evaluate a graph symbolically, creating nodes in the storage.
+
+        This is used internally to create the visualization of symbolic graphs.
+        Recursively creates all nodes by parsing the graph structure.
+        Assumes that nested graphs are wrapped in a Const parent node.
+        Starts from the final output node.
+
+        :param graph: The graph to evaluate symbolically.
+        :type graph: GraphData
+        :param parent_loc: The location of the parent node only relevant for Const nodes, defaults to Loc().
+        :type parent_loc: Loc, optional
+        """
+        self.nodes[parent_loc] = NodeData(
+            definition=Eval((-1, "body"), {}),
+            call_args=None,
+            is_done=False,
+            has_error=False,
+            metadata={},
+            error_logs="",
+            outputs={output: None for output in graph.node_outputs[graph.output_idx()]},
+        )
+        self.nodes[parent_loc].metadata["start_time"] = str(datetime.now())
+        self.nodes[parent_loc.N(-1)] = NodeData(
+            definition=None,
+            call_args=None,
+            is_done=False,
+            has_error=False,
+            metadata={},
+            error_logs="",
+            outputs={"body": graph.model_dump_json().encode()},
+        )
+
+    def _node_from_loc(self, node_location: Loc) -> NodeData:
+        if node_location in self.nodes:
+            return self.nodes[node_location]
+        graph = self.graph
+        if len(graph.nodes) == 0:
+            raise TierkreisError("Cannot convert location to node. Reason: Empty Graph")
+        previous_graph = graph
+        node_id = 0
+        node: NodeDef | None = graph.nodes[0]
+        loc = Loc()
+        for step in node_location.steps():
+            if step == "-":
+                continue
+            _, node_id = step
+
+            loc = Loc(loc + "." + step[0] + str(step[1]))
+            if loc in self.nodes:
+                #
+                node = self.nodes[loc].definition
+                if node is None:
+                    graph = self.nodes[loc].outputs["body"]
+                    continue
+                match node.type:
+                    case "eval":
+                        if node.graph[0] == -1:
+                            continue
+                        graph = graph.nodes[node.graph[0]].value
+                    case "map" | "loop":
+                        graph = graph.nodes[node.body[0]].value
+                    case (
+                        "const" | "function" | "input" | "output" | "ifelse" | "eifelse"
+                    ):
+                        pass
+                    case _:
+                        assert_never(node)
+                continue
+
+            if isinstance(node_id, str):
+                if "-" in node_id:
+                    node_id = node_id.split("-")[1]
+                if node_id == "*":  # potentially "*" in node_id
+                    node_id = "0"
+                try:
+                    node_id = int(node_id)
+                except ValueError:
+                    node_id = 0
+
+            node = graph.nodes[node_id]
+            previous_graph = graph
+            match node.type:
+                case "eval":
+                    graph = graph.nodes[node.graph[0]].value
+                    self.nodes[loc.N(-1)] = NodeData(
+                        outputs={"body": graph.model_dump_json().encode()},
+                    )
+
+                case "loop":
+                    graph = graph.nodes[node.body[0]].value
+                    self.nodes[loc.L(0)] = NodeData(
+                        definition=Eval((-1, "body"), {}),
+                        outputs={
+                            output: None
+                            for output in graph.node_outputs[graph.output_idx()]
+                        },
+                    )
+                    self.nodes[loc.L(0).N(-1)] = NodeData(
+                        outputs={"body": graph.model_dump_json().encode()},
+                    )
+
+                case "map":
+                    graph = graph.nodes[node.body[0]].value
+                    outputs = {
+                        output: None
+                        for output in graph.node_outputs[graph.output_idx()]
+                    }
+                    if "*" in outputs:
+                        outputs["0"] = None
+                    self.nodes[loc.M("0")] = NodeData(
+                        definition=Eval((-1, "body"), {}),
+                        outputs=outputs,
+                    )
+                    self.nodes[loc.M("0").N(-1)] = NodeData(
+                        outputs={"body": graph.model_dump_json().encode()},
+                    )
+                case "const" | "function" | "input" | "output" | "ifelse" | "eifelse":
+                    pass
+                case _:
+                    assert_never(node)
+        # Have found the node, now populate the node data correctly
+        if node_location not in self.nodes:
+            outputs = {output: None for output in previous_graph.node_outputs[node_id]}
+            if "*" in outputs:
+                outputs["0"] = None
+            self.nodes[node_location] = NodeData(
+                definition=node,
+                outputs=outputs,
+            )
+
+        return self.nodes[node_location]
+
+    def _evaluate_symbolic(self, graph: GraphData, parent_loc: Loc = Loc()) -> None:
+        unfinished_inputs = [((graph.output_idx(), ""), parent_loc)]
+        for input, parent in unfinished_inputs:
+            output_id = input[0]
+            output_node = graph.nodes[output_id]
+            outputs = list(graph.node_outputs[output_id])
+            loc = parent.N(output_id)
+            if "*" in outputs:
+                outputs.append("0")
+            self.nodes[loc] = NodeData(
+                definition=output_node,
+                call_args=None,
+                is_done=False,
+                has_error=False,
+                metadata={},
+                error_logs="",
+                outputs={output: None for output in outputs},
+            )
+            new_unfinished_inputs = self._in_edges(output_node, output_id, parent)
+            unfinished_inputs += new_unfinished_inputs
+
+    def _in_edges(
+        self, node: NodeDef, node_id: int, parent: Loc
+    ) -> list[tuple[ValueRef, Loc]]:
+        """Mimics tierkreis.controller.storage.adjacency.in_edges.
+        This lets us know which nodes are the inputs of the current node.
+        """
+        parents = [(x, parent) for x in node.inputs.values()]
+        node_loc = parent.N(node_id)
+        match node.type:
+            case "eval":
+                parents.append((node.graph, node_loc))
+            case "loop":
+                parents.append((node.body, node_loc))
+            case "map":
+                # Unevaluated maps have a body but no child element to evaluate it
+                # We add the first child "0" to allow visualization of the body
+                self.nodes[node_loc.M("0")] = NodeData(
+                    definition=Eval((-1, "body"), {})
+                )
+                parents.append((node.body, node_loc))
+            case "ifelse" | "eifelse":
+                # We want to see conditional branches in both cases
+                parents.append((node.pred, node_loc))
+                parents.append((node.if_true, node_loc))
+                parents.append((node.if_false, node_loc))
+            case "const":
+                # Const nodes can be graphs themselves, so we need to handle them
+                self._handle_const(node, node_id, parent)
+            case "function" | "input" | "output":
+                pass
+            case _:
+                assert_never(node)
+
+        return parents
+
+    def _handle_const(self, node: Const, node_id: int, parent: Loc) -> None:
+        if parent.parent() is None:
+            raise TierkreisError(
+                f"Node {node_id} with value {node.value} cannot be a graph output without a parent."
+            )
+        value: GraphData | None = None
+        # Try to load a nested graph from value
+        if isinstance(node.value, GraphData):
+            value = node.value
+        elif isinstance(node.value, dict):
+            try:
+                value = GraphData(**node.value)
+            except TypeError:
+                raise TierkreisError(f"Cannot convert {node}s value to GraphData.")
+        if value is None:
+            # not a graph
+            return
+
+        self.nodes[parent.parent().N(node_id)] = NodeData(  # type: ignore
+            definition=Const(value),
+            outputs={"value": value.model_dump_json().encode()},
+        )
+
+        if parent.M("0") in self.nodes:
+            # This is a map node
+            parent = parent.M("0")
+        self.evaluate_symbolic(value, parent)

--- a/tierkreis/tierkreis/controller/storage/in_memory.py
+++ b/tierkreis/tierkreis/controller/storage/in_memory.py
@@ -143,7 +143,7 @@ class ControllerInMemoryStorage:
                 output_name
             ]:
                 return output
-            return b""
+            return b"null"
         raise TierkreisError(f"No output named {output_name} in node {node_location}")
 
     def read_output_ports(self, node_location: Loc) -> list[PortID]:

--- a/tierkreis/tierkreis/controller/storage/in_memory.py
+++ b/tierkreis/tierkreis/controller/storage/in_memory.py
@@ -1,4 +1,5 @@
 from collections import defaultdict
+from datetime import datetime
 from pathlib import Path
 from uuid import UUID
 from typing import Any
@@ -160,7 +161,10 @@ class ControllerInMemoryStorage:
         return self.nodes[self.loc_to_path(node_location)].metadata
 
     def write_metadata(self, node_location: Loc) -> None:
-        self.nodes[self.loc_to_path(node_location)].metadata = {"name": self.name}
+        self.nodes[self.loc_to_path(node_location)].metadata = {
+            "name": self.name,
+            "start": str(datetime.now()),
+        }
 
     def clean_graph_files(self) -> None:
         uid = os.getuid()

--- a/tierkreis/tierkreis/utils.py
+++ b/tierkreis/tierkreis/utils.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from uuid import UUID
 from unittest.mock import MagicMock, patch
 import logging
@@ -29,7 +30,9 @@ def visualize_graph(
     """
     storage = GraphDataStorage(UUID(int=0), graph=graph)
     os.environ["TKR_STORAGE"] = "GraphDataStorage"
-    get_workflows.return_value = [WorkflowDisplay(id=UUID(int=0), id_int=0, name="tmp")]
+    get_workflows.return_value = [
+        WorkflowDisplay(id=UUID(int=0), id_int=0, name="tmp", start=str(datetime.now()))
+    ]
     get_storage.return_value = storage
 
     start()

--- a/tierkreis/tierkreis/utils.py
+++ b/tierkreis/tierkreis/utils.py
@@ -1,38 +1,28 @@
-from datetime import datetime
 from uuid import UUID
-from unittest.mock import MagicMock, patch
 import logging
 import os
 
 from tierkreis.controller.data.graph import GraphData
+from tierkreis.controller.storage.protocol import ControllerStorage
 from tierkreis.controller.storage.graphdata import GraphDataStorage
-from tierkreis_visualization.data.workflows import WorkflowDisplay
-from tierkreis_visualization.main import start
+from tierkreis_visualization.main import start_with_storage_fn
 
 logger = logging.getLogger(__name__)
 
 
-@patch("tierkreis_visualization.routers.workflows.get_storage")
-@patch("tierkreis_visualization.routers.workflows.get_workflows")
 def visualize_graph(
     graph: GraphData,
-    get_workflows: MagicMock,
-    get_storage: MagicMock,
 ) -> None:
     """Visualize a computation graph in a web browser.
 
     :param graph: The computation graph to visualize.
     :type graph: GraphData
-    :param get_workflows: Internal; Used to inject the workflow retrieval mock.
-    :type get_workflows: MagicMock
-    :param get_storage: Internal; Used to inject the storage mock.
-    :type get_storage: MagicMock
     """
     storage = GraphDataStorage(UUID(int=0), graph=graph)
     os.environ["TKR_STORAGE"] = "GraphDataStorage"
-    get_workflows.return_value = [
-        WorkflowDisplay(id=UUID(int=0), id_int=0, name="tmp", start=str(datetime.now()))
-    ]
-    get_storage.return_value = storage
 
-    start()
+    def get_storage(workflow_id: UUID) -> ControllerStorage:
+        return storage
+
+    start_with_storage_fn(get_storage)
+    os.environ["TKR_STORAGE"] = "FileStorage"

--- a/tierkreis/tierkreis/utils.py
+++ b/tierkreis/tierkreis/utils.py
@@ -1,0 +1,35 @@
+from uuid import UUID
+from unittest.mock import MagicMock, patch
+import logging
+import os
+
+from tierkreis.controller.data.graph import GraphData
+from tierkreis.controller.storage.graphdata import GraphDataStorage
+from tierkreis_visualization.data.workflows import WorkflowDisplay
+from tierkreis_visualization.main import start
+
+logger = logging.getLogger(__name__)
+
+
+@patch("tierkreis_visualization.routers.workflows.get_storage")
+@patch("tierkreis_visualization.routers.workflows.get_workflows")
+def visualize_graph(
+    graph: GraphData,
+    get_workflows: MagicMock,
+    get_storage: MagicMock,
+) -> None:
+    """Visualize a computation graph in a web browser.
+
+    :param graph: The computation graph to visualize.
+    :type graph: GraphData
+    :param get_workflows: Internal; Used to inject the workflow retrieval mock.
+    :type get_workflows: MagicMock
+    :param get_storage: Internal; Used to inject the storage mock.
+    :type get_storage: MagicMock
+    """
+    storage = GraphDataStorage(UUID(int=0), graph=graph)
+    os.environ["TKR_STORAGE"] = "GraphDataStorage"
+    get_workflows.return_value = [WorkflowDisplay(id=UUID(int=0), id_int=0, name="tmp")]
+    get_storage.return_value = storage
+
+    start()

--- a/tierkreis_visualization/frontend/src/components/types.ts
+++ b/tierkreis_visualization/frontend/src/components/types.ts
@@ -5,6 +5,7 @@ export interface InfoProps {
 export interface Workflow {
   id: string;
   name: string;
+  start: string;
 }
 
 export interface HandleProps {

--- a/tierkreis_visualization/tierkreis_visualization/data/eval.py
+++ b/tierkreis_visualization/tierkreis_visualization/data/eval.py
@@ -105,11 +105,7 @@ def get_eval_node(
         for p0, (idx, p1) in in_edges(node).items():
             value = None
             if p1 in storage.read_output_ports(node_location.N(idx)):
-                try:
-                    value = json.loads(storage.read_output(node_location.N(idx), p1))
-                except json.decoder.JSONDecodeError:
-                    # In symbolic evaluation output could be "" causing an error
-                    value = None
+                value = json.loads(storage.read_output(node_location.N(idx), p1))
 
             py_edge = PyEdge(
                 from_node=idx, from_port=p1, to_node=i, to_port=p0, value=value

--- a/tierkreis_visualization/tierkreis_visualization/data/workflows.py
+++ b/tierkreis_visualization/tierkreis_visualization/data/workflows.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 import os
 from uuid import UUID
 
@@ -10,6 +11,7 @@ class WorkflowDisplay(BaseModel):
     id: UUID
     id_int: int
     name: str | None
+    start: str
 
 
 def get_workflows() -> list[WorkflowDisplay]:
@@ -21,7 +23,10 @@ def get_workflows() -> list[WorkflowDisplay]:
             id = UUID(folder)
             metadata = get_storage(id).read_metadata(Loc(""))
             name = metadata["name"] or "workflow"
-            workflows.append(WorkflowDisplay(id=id, id_int=int(id), name=name))
+            start = metadata.get("start", str(datetime.now()))
+            workflows.append(
+                WorkflowDisplay(id=id, id_int=int(id), name=name, start=start)
+            )
         except (TypeError, ValueError):
             continue
 

--- a/tierkreis_visualization/tierkreis_visualization/data/workflows.py
+++ b/tierkreis_visualization/tierkreis_visualization/data/workflows.py
@@ -15,6 +15,17 @@ class WorkflowDisplay(BaseModel):
 
 
 def get_workflows() -> list[WorkflowDisplay]:
+    storage_type = os.environ.get("TKR_STORAGE", "FileStorage")
+    if storage_type == "GraphDataStorage":
+        return [
+            WorkflowDisplay(
+                id=UUID(int=0), id_int=0, name="tmp", start=str(datetime.now())
+            )
+        ]
+    return get_workflows_from_disk()
+
+
+def get_workflows_from_disk() -> list[WorkflowDisplay]:
     folders = os.listdir(CONFIG.tierkreis_path)
     folders.sort()
     workflows: list[WorkflowDisplay] = []

--- a/tierkreis_visualization/tierkreis_visualization/main.py
+++ b/tierkreis_visualization/tierkreis_visualization/main.py
@@ -1,10 +1,14 @@
 from pathlib import Path
+from typing import Callable
+from uuid import UUID
 from fastapi.middleware.cors import CORSMiddleware
 
 
 from fastapi import FastAPI, Request
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import RedirectResponse
+from tierkreis.controller.storage.protocol import ControllerStorage
+from tierkreis_visualization.config import get_storage
 import uvicorn
 
 from tierkreis_visualization.routers.workflows import router as workflows_router
@@ -37,4 +41,14 @@ def read_root(request: Request):
 
 
 def start():
+    app.state.get_storage_fn = get_storage
+    uvicorn.run(app, reload=True)
+
+
+def start_with_storage_fn(get_storage_fn: Callable[[UUID], ControllerStorage]):
+    app.state.get_storage_fn = get_storage_fn
     uvicorn.run(app)
+
+
+if __name__ == "__main__":
+    start()

--- a/tierkreis_visualization/tierkreis_visualization/routers/workflows.py
+++ b/tierkreis_visualization/tierkreis_visualization/routers/workflows.py
@@ -45,6 +45,8 @@ async def handle_websocket(
     node_location = parse_node_location(node_location_str)
     # currently we are watching the entire workflow in the frontend
     node_path = CONFIG.tierkreis_path / str(workflow_id)
+    if not node_path.exists():
+        return
     async for _changes in awatch(node_path, recursive=True):
         ctx = get_node_data(workflow_id, node_location)
         await websocket.send_json(ctx)

--- a/tierkreis_visualization/tierkreis_visualization/routers/workflows.py
+++ b/tierkreis_visualization/tierkreis_visualization/routers/workflows.py
@@ -9,11 +9,13 @@ from pydantic import BaseModel
 from starlette.responses import JSONResponse, PlainTextResponse
 from starlette.websockets import WebSocket, WebSocketDisconnect
 
+from tierkreis.controller.data.core import PortID
 from tierkreis.controller.data.location import Loc, WorkerCallArgs
+from tierkreis.controller.storage.protocol import ControllerStorage
 from tierkreis.exceptions import TierkreisError
 from watchfiles import awatch  # type: ignore
 
-from tierkreis_visualization.config import CONFIG, get_storage, templates
+from tierkreis_visualization.config import CONFIG, templates
 from tierkreis_visualization.data.eval import get_eval_node
 from tierkreis_visualization.data.function import get_function_node
 from tierkreis_visualization.data.loop import get_loop_node
@@ -31,16 +33,20 @@ logger = logging.getLogger(__name__)
 async def websocket_endpoint(
     websocket: WebSocket, workflow_id: UUID, node_location_str: str
 ) -> None:
+    storage = websocket.app.state.get_storage_fn(workflow_id)
     try:
         await websocket.accept()
         # Handle WebSocket connection.
-        await handle_websocket(websocket, workflow_id, node_location_str)
+        await handle_websocket(websocket, workflow_id, node_location_str, storage)
     except WebSocketDisconnect:
         pass
 
 
 async def handle_websocket(
-    websocket: WebSocket, workflow_id: UUID, node_location_str: str
+    websocket: WebSocket,
+    workflow_id: UUID,
+    node_location_str: str,
+    storage: ControllerStorage,
 ) -> None:
     node_location = parse_node_location(node_location_str)
     # currently we are watching the entire workflow in the frontend
@@ -48,7 +54,7 @@ async def handle_websocket(
     if not node_path.exists():
         return
     async for _changes in awatch(node_path, recursive=True):
-        ctx = get_node_data(workflow_id, node_location)
+        ctx = get_node_data(workflow_id, node_location, storage)
         await websocket.send_json(ctx)
 
 
@@ -74,15 +80,15 @@ def parse_node_location(node_location_str: str) -> Loc:
     return Loc(node_location_str)
 
 
-def get_errored_nodes(workflow_id: UUID) -> list[Loc]:
-    storage = get_storage(workflow_id)
+def get_errored_nodes(storage: ControllerStorage) -> list[Loc]:
     errored_nodes = storage.read_errors(Loc("-"))
     return [parse_node_location(node) for node in errored_nodes.split("\n")]
 
 
-def get_node_data(workflow_id: UUID, loc: Loc) -> dict[str, Any]:
-    storage = get_storage(workflow_id)
-    errored_nodes = get_errored_nodes(workflow_id)
+def get_node_data(
+    workflow_id: UUID, loc: Loc, storage: ControllerStorage
+) -> dict[str, Any]:
+    errored_nodes = get_errored_nodes(storage)
 
     try:
         node = storage.read_node_def(loc)
@@ -151,34 +157,47 @@ def get_node_data(workflow_id: UUID, loc: Loc) -> dict[str, Any]:
     return ctx
 
 
-async def node_stream(workflow_id: UUID, node_location: Loc):
+async def node_stream(
+    workflow_id: UUID, node_location: Loc, storage: ControllerStorage
+):
     node_path = CONFIG.tierkreis_path / str(workflow_id) / str(node_location)
     async for _changes in awatch(node_path, recursive=False):
         if (node_path / "definition").exists():
-            ctx = get_node_data(workflow_id, node_location)
+            ctx = get_node_data(workflow_id, node_location, storage)
             yield f"event: message\ndata: {json.dumps(ctx)}\n\n"
 
 
 @router.get("/{workflow_id}/nodes/{node_location_str}")
-def get_node(request: Request, workflow_id: UUID, node_location_str: str):
+def get_node(
+    request: Request,
+    workflow_id: UUID,
+    node_location_str: str,
+):
     node_location = parse_node_location(node_location_str)
-    ctx = get_node_data(workflow_id, node_location)
+    storage = request.app.state.get_storage_fn(workflow_id)
+    ctx = get_node_data(workflow_id, node_location, storage)
     if request.headers["Accept"] == "application/json":
         return JSONResponse(ctx)
 
     if request.headers["Accept"] == "text/event-stream":
         return StreamingResponse(
-            node_stream(workflow_id, node_location), media_type="text/event-stream"
+            node_stream(workflow_id, node_location, storage),
+            media_type="text/event-stream",
         )
 
     return templates.TemplateResponse(request=request, name=ctx["name"], context=ctx)
 
 
 @router.get("/{workflow_id}/nodes/{node_location_str}/inputs/{port_name}")
-def get_input(workflow_id: UUID, node_location_str: str, port_name: str):
+def get_input(
+    request: Request,
+    workflow_id: UUID,
+    node_location_str: str,
+    port_name: str,
+):
     try:
         node_location = parse_node_location(node_location_str)
-        storage = get_storage(workflow_id)
+        storage = request.app.state.get_storage_fn(workflow_id)
         definition = storage.read_worker_call_args(node_location)
 
         with open(definition.inputs[port_name], "rb") as fh:
@@ -188,25 +207,34 @@ def get_input(workflow_id: UUID, node_location_str: str, port_name: str):
 
 
 @router.get("/{workflow_id}/nodes/{node_location_str}/outputs/{port_name}")
-def get_output(workflow_id: UUID, node_location_str: str, port_name: str):
-    output_file = (
-        CONFIG.tierkreis_path
-        / str(workflow_id)
-        / node_location_str
-        / "outputs"
-        / port_name
-    )
+def get_output(
+    request: Request,
+    workflow_id: UUID,
+    node_location_str: str,
+    port_name: str,
+):
+    storage = request.app.state.get_storage_fn(workflow_id)
     try:
-        with open(output_file, "rb") as fh:
-            return JSONResponse(json.loads(fh.read()))
+        return JSONResponse(
+            json.loads(
+                storage.read_output(
+                    parse_node_location(node_location_str), PortID(port_name)
+                )
+            )
+        )
+
     except FileNotFoundError as e:
         return PlainTextResponse(str(e))
 
 
 @router.get("/{workflow_id}/nodes/{node_location_str}/logs")
-def get_function_logs(workflow_id: UUID, node_location_str: str) -> PlainTextResponse:
+def get_function_logs(
+    request: Request,
+    workflow_id: UUID,
+    node_location_str: str,
+) -> PlainTextResponse:
     node_location = parse_node_location(node_location_str)
-    storage = get_storage(workflow_id)
+    storage = request.app.state.get_storage_fn(workflow_id)
     try:
         definition = storage.read_node_def(node_location)
     except (FileNotFoundError, TierkreisError):
@@ -230,8 +258,11 @@ def get_function_logs(workflow_id: UUID, node_location_str: str) -> PlainTextRes
 
 
 @router.get("/{workflow_id}/logs")
-def get_logs(workflow_id: UUID) -> PlainTextResponse:
-    storage = get_storage(workflow_id)
+def get_logs(
+    request: Request,
+    workflow_id: UUID,
+) -> PlainTextResponse:
+    storage = request.app.state.get_storage_fn(workflow_id)
     if not storage.logs_path.is_file():
         return PlainTextResponse("Logfile not found.")
 
@@ -244,9 +275,13 @@ def get_logs(workflow_id: UUID) -> PlainTextResponse:
 
 
 @router.get("/{workflow_id}/nodes/{node_location_str}/errors")
-def get_errors(workflow_id: UUID, node_location_str: str):
+def get_errors(
+    request: Request,
+    workflow_id: UUID,
+    node_location_str: str,
+):
     node_location = parse_node_location(node_location_str)
-    storage = get_storage(workflow_id)
+    storage = request.app.state.get_storage_fn(workflow_id)
     if not storage.node_has_error(node_location):
         return PlainTextResponse("Node has no errors.", status_code=404)
 


### PR DESCRIPTION
closes: #114 

Implements a read-only storage for graph data objects that can be handed to the visualizer.
Assumes a graph has a single output