### PR TITLE
chore: insist MAP nodes have integer idx

### DIFF
--- a/tierkreis/tests/controller/test_locs.py
+++ b/tierkreis/tests/controller/test_locs.py
@@ -8,7 +8,7 @@ node_location_1 = node_location_1.L(0)
 node_location_1 = node_location_1.N(3)
 node_location_1 = node_location_1.L(2)
 node_location_1 = node_location_1.N(0)
-node_location_1 = node_location_1.M("map_port")
+node_location_1 = node_location_1.M(7)
 node_location_1 = node_location_1.N(0)
 
 
@@ -28,7 +28,7 @@ node_location_4 = Loc()
 @pytest.mark.parametrize(
     ["node_location", "loc_str"],
     [
-        (node_location_1, "-.N0.L0.N3.L2.N0.Mmap_port.N0"),
+        (node_location_1, "-.N0.L0.N3.L2.N0.M7.N0"),
         (node_location_2, "-.N0.L0.N3.N8.N0"),
         (node_location_3, "-.N0"),
         (node_location_4, "-"),

--- a/tierkreis/tierkreis/controller/data/location.py
+++ b/tierkreis/tierkreis/controller/data/location.py
@@ -23,9 +23,7 @@ class WorkerCallArgs(BaseModel):
     logs_path: Optional[Path]
 
 
-NodeStep = (
-    Literal["-"] | tuple[Literal["N", "L"], NodeIndex] | tuple[Literal["M"], PortID]
-)
+NodeStep = Literal["-"] | tuple[Literal["N", "L", "M"], NodeIndex]
 
 
 class Loc(str):
@@ -38,7 +36,7 @@ class Loc(str):
     def L(self, idx: int) -> "Loc":
         return Loc(str(self) + f".L{idx}")
 
-    def M(self, idx: PortID) -> "Loc":
+    def M(self, idx: int) -> "Loc":
         return Loc(str(self) + f".M{idx}")
 
     @staticmethod
@@ -83,8 +81,8 @@ class Loc(str):
                     steps.append(("N", int(idx_str)))
                 case ("L", idx_str):
                     steps.append(("L", int(idx_str)))
-                case ("M", _port):
-                    steps.append(("M", step_str[1:]))
+                case ("M", idx_str):
+                    steps.append(("M", int(idx_str)))
                 case _:
                     raise TierkreisError(f"Invalid Loc: {self}")
 

--- a/tierkreis/tierkreis/controller/storage/adjacency.py
+++ b/tierkreis/tierkreis/controller/storage/adjacency.py
@@ -39,3 +39,8 @@ def unfinished_inputs(
     return [
         x for x in in_edges(node).values() if not storage.is_node_finished(loc.N(x[0]))
     ]
+
+
+def outputs_iter(storage: ControllerStorage, loc: Loc) -> list[tuple[int, PortID]]:
+    eles = storage.read_output_ports(loc)
+    return [(int(x.split("-")[-1]), x) for x in eles]

--- a/tierkreis_visualization/tierkreis_visualization/data/map.py
+++ b/tierkreis_visualization/tierkreis_visualization/data/map.py
@@ -1,5 +1,6 @@
 from pydantic import BaseModel
 from tierkreis.controller.data.location import Loc
+from tierkreis.controller.storage.adjacency import outputs_iter
 from tierkreis.controller.storage.protocol import ControllerStorage
 from tierkreis.controller.data.graph import Map
 from tierkreis.exceptions import TierkreisError
@@ -20,15 +21,13 @@ def get_map_node(
         raise TierkreisError("MAP node must have parent.")
 
     first_ref = next(x for x in map.inputs.values() if x[1] == "*")
-    map_eles = storage.read_output_ports(parent.N(first_ref[0]))
+    map_eles = outputs_iter(storage, parent.N(first_ref[0]))
     nodes: list[PyNode] = []
-    for ele in map_eles:
-        node = PyNode(
-            id=ele, status="Started", function_name=ele, node_location=loc.M(ele)
-        )
-        if check_error(loc.M(ele), errored_nodes):
+    for i, ele in map_eles:
+        node = PyNode(id=i, status="Started", function_name=ele, node_location=loc.M(i))
+        if check_error(loc.M(i), errored_nodes):
             node.status = "Error"
-        elif storage.is_node_finished(loc.M(ele)):
+        elif storage.is_node_finished(loc.M(i)):
             node.status = "Finished"
         nodes.append(node)
 

--- a/tierkreis_visualization/tierkreis_visualization/data/models.py
+++ b/tierkreis_visualization/tierkreis_visualization/data/models.py
@@ -1,12 +1,11 @@
 from typing import Literal, Any
 from pydantic import BaseModel
-from tierkreis.controller.data.core import PortID
 
 NodeStatus = Literal["Not started", "Started", "Error", "Finished"]
 
 
 class PyNode(BaseModel):
-    id: int | PortID
+    id: int
     status: NodeStatus
     function_name: str
     node_location: str = ""


### PR DESCRIPTION
Some clean up of internals. All the rest of the node types had integer indices and the typed graph builder only produces integers for map nodes anyway.

https://github.com/CQCL/tierkreis/issues/149

* Update definition of `NodeStep` and `Loc.steps` to only allow integer values for the index of a map node.
* Create `outputs_iter` function that returns an list of nodes, which is intended to be used in the situation where we cannot deduce their number before runtime. Use this function in place of `storage.read_output_ports` when dealing with map nodes.
* Restrict the `PyNode.id` to be an integer again. This should be a non-breaking change for the front-end.