### PR TITLE
chore: include frontend assets in PyPI package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,20 +11,13 @@ jobs:
       id-token: write
     strategy:
       matrix:
-        python-version: ['3.12']
+        python-version: ["3.12"]
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
+      - name: Build frontend assets
+        uses: ./.github/workflows/run-command.yml
         with:
-          fetch-depth: '0'
-
-      - name: Set up uv & venv
-        uses: astral-sh/setup-uv@v5
-        with:
-          version: ${{ env.UV_VERSION }}
-          enable-cache: true
-          python-version: ${{ matrix.python-version }}
-          cache-dependency-glob: uv.lock
+          command_name: prod
+          command: just prod
 
       - name: Build package
         run: |

--- a/tierkreis_visualization/pyproject.toml
+++ b/tierkreis_visualization/pyproject.toml
@@ -16,6 +16,9 @@ dependencies = [
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
+[tool.hatch.build.targets.wheel.force-include]
+"./tierkreis_visualization/static/dist" = "tierkreis_visualization/static/dist"
+
 [tool.uv.sources]
 tierkreis = { workspace = true }
 


### PR DESCRIPTION
This one might take a bit of pushing through CI with the various release processes. Tested locally by importing tierkreis_visualization (non-editable!) into a new project and seeing a not found error. Then with the change to `pyproject.toml` the dist is included and the visualiser loads. 