### PR TITLE
Checkout code first in CI

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,6 +11,9 @@ jobs:
 
     runs-on: ubuntu-24.04
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
       - name: Build docs
         uses: ./.github/workflows/run-command.yml
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,9 @@ jobs:
       matrix:
         python-version: ["3.12"]
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
       - name: Build frontend assets
         uses: ./.github/workflows/run-command.yml
         with:


### PR DESCRIPTION
Cannot use reusable workflow without checkout first. Hopefully should get CI moving again.