### PR TITLE
chore: pretty print json values to checkpoints

### DIFF
--- a/tierkreis/tierkreis/controller/data/types.py
+++ b/tierkreis/tierkreis/controller/data/types.py
@@ -289,7 +289,7 @@ def bytes_from_ptype(ptype: PType, annotation: type[PType] | None = None) -> byt
         case bytes():
             return ser  # Top level bytes should be a clean pass-through.
         case _:
-            return json.dumps(ser, cls=TierkreisEncoder).encode()
+            return json.dumps(ser, cls=TierkreisEncoder, indent=2).encode()
 
 
 def coerce_from_annotation[T: PType](ser: Any, annotation: type[T] | None) -> T:


### PR DESCRIPTION
Change the serialization of json values to contain indents in the checkpoints directory. This will have a marginally negative impact on performance but makes the values much more human readable both in the checkpoints directory as well as in the visualiser