### PR TITLE
ci: Group dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,15 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+      day: "friday"
     labels:
       - "python"
       - "dependencies"
+    groups:
+      third-party-minor:
+        update-types:
+          - "minor"
+          - "patch"
+      third-party-major:
+        update-types:
+          - "major"


### PR DESCRIPTION
Group dependabot by minor/patch updates or by major updates.

Hopefully the former can just be merged without much change and some of the major updates may need manual intervention.

Also sets the dependabot update check day to Friday.