### PR TITLE
feat: Refactor and expand orchestrator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -213,6 +213,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "serde",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -370,6 +383,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
+name = "delegate"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "780eb241654bf097afb00fc5f054a09b687dad862e485fdcf8399bb056565370"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -409,6 +433,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "equivalent"
@@ -469,6 +499,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
@@ -896,6 +932,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1157,6 +1202,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
+name = "portgraph"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a1395575e261a0c0dd2d360ac4e3b14a4c9f68647ee12e59d96af959e4c0f79"
+dependencies = [
+ "bitvec",
+ "delegate",
+ "itertools",
+ "num-traits",
+ "serde",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1296,6 +1356,12 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
@@ -1709,6 +1775,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
 name = "target-lexicon"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1772,11 +1844,13 @@ name = "tierkreis"
 version = "0.1.0"
 dependencies = [
  "axum",
+ "bitvec",
  "chrono",
  "clap",
  "dashmap",
  "futures",
  "miette",
+ "portgraph",
  "pyo3",
  "regex",
  "rstest",
@@ -2426,6 +2500,15 @@ name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
 
 [[package]]
 name = "yaml-rust"

--- a/tierkreis/Cargo.toml
+++ b/tierkreis/Cargo.toml
@@ -10,11 +10,13 @@ name = "tkr"
 
 [dependencies]
 axum = { version = "0.8.8", features = ["ws", "http2"] }
+bitvec = "1.0.1"
 chrono = { version = "0.4.44", features = ["serde"] }
 clap = { version = "4.6.0", features = ["derive"] }
 dashmap = "6.1.0"
 futures = "0.3.32"
 miette = { version = "7.6.0", features = ["fancy", "syntect-highlighter"] }
+portgraph = { version = "0.16.1", features = ["serde"] }
 pyo3 = { version = "0.28.2", features = ["auto-initialize", "anyhow", "abi3"] }
 regex = "1.12.3"
 serde = { version = "1.0.228", features = ["derive"] }

--- a/tierkreis/src/graph.rs
+++ b/tierkreis/src/graph.rs
@@ -2,31 +2,220 @@
 This module defines the Workflow graph representation.
 */
 
-use serde_json::Value;
+use std::collections::HashMap;
 
-/// [Node] is a placeholder enum for the kinds of operations that can appear
-/// in a Workflow graph. To be replaced with something compatible with the
-/// existing python code.
-pub enum Node {
-    /// An operation performed by a Worker.
-    Task {
-        /// The name of the Worker to call.
-        worker_name: String,
-        /// The name of the Task to call.
-        task_name: String,
-    },
-    /// An input to the Workflow.
+use bitvec::vec::BitVec;
+use miette::{Context, IntoDiagnostic, miette};
+use portgraph::{
+    Direction, LinkMut, LinkView, NodeIndex, PortGraph, PortIndex, PortMut, PortView,
+    algorithms::{TopoSort, toposort_filtered},
+};
+use serde::{Deserialize, Serialize};
+
+/// Possible definitions for Nodes in the [`WorkflowGraph`].
+#[derive(Debug, Serialize, Deserialize)]
+pub enum NodeDefinition {
+    /// A node that takes input values to the Graph.
     Input {
-        /// The name of the Workflow input to capture.
+        /// The name of the input value to the Graph.
         name: String,
     },
-    /// The output of the Workflow
+    /// A node that returns output values from the Graph.
     Output {},
-    /// A constant Value in the Workflow.
+    /// A node that loads a constant value into the Graph.
     Const {
-        /// The constant value to return.
-        value: Value,
+        /// The constant value to load.
+        value: serde_json::Value,
     },
-    /// A sub-execution.
+    /// A node that defines a Task to be performed by a Worker in the Graph.
+    Task {
+        /// The name of the Worker to invoke.
+        worker_name: String,
+        /// The name of the Task to perform.
+        task_name: String,
+    },
+    /// A node that defines that a Subgraph needs to be evaluated.
     Eval {},
+}
+
+/// The [`WorkflowGraph`] defines a Workflow that can be evaluated
+/// by the Tierkreis runtime.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct WorkflowGraph {
+    graph: PortGraph,
+    node_definitions: HashMap<NodeIndex, NodeDefinition>,
+    port_indices: HashMap<NodeIndex, HashMap<String, PortIndex>>,
+    port_names: HashMap<PortIndex, String>,
+    output_node: NodeIndex,
+}
+
+impl WorkflowGraph {
+    /// Create a new [`WorkflowGraph`] with an iterator of output names.
+    ///
+    /// The [`WorkflowGraph`] will be created with a single Output node ports
+    /// of the provided names.
+    pub fn new(graph_outputs: impl IntoIterator<Item = String>) -> Self {
+        let graph_outputs: Vec<String> = graph_outputs.into_iter().collect();
+        let mut graph = PortGraph::new();
+        let idx = graph.add_node(graph_outputs.len(), 0);
+
+        let mut port_names = HashMap::new();
+        let mut output_port_indices = HashMap::new();
+        let mut port_indices = HashMap::new();
+
+        graph
+            .inputs(idx)
+            .zip(graph_outputs)
+            .for_each(|(p, node_input)| {
+                output_port_indices.insert(node_input.clone(), p);
+                port_names.insert(p, node_input);
+            });
+
+        port_indices.insert(idx, output_port_indices);
+
+        let mut node_definitions = HashMap::new();
+        node_definitions.insert(idx, NodeDefinition::Output {});
+
+        Self {
+            graph,
+            node_definitions,
+            port_indices,
+            port_names,
+            output_node: idx,
+        }
+    }
+
+    /// Retrieve the [`NodeIndex`] of the output node.
+    #[must_use]
+    pub fn output_idx(&self) -> NodeIndex {
+        self.output_node
+    }
+
+    /// Retrieve the [`NodeDefinition`] for a node if it exists.
+    #[must_use]
+    pub fn node_definition(&self, node: NodeIndex) -> Option<&NodeDefinition> {
+        self.node_definitions.get(&node)
+    }
+
+    /// Add a node to the graph using a definition and the names of the input and output ports.
+    pub fn add_node(
+        &mut self,
+        node_definition: NodeDefinition,
+        inputs: impl IntoIterator<Item = String>,
+        outputs: impl IntoIterator<Item = String>,
+    ) -> NodeIndex {
+        let inputs: Vec<String> = inputs.into_iter().collect();
+        let outputs: Vec<String> = outputs.into_iter().collect();
+        let idx = self.graph.add_node(inputs.len(), outputs.len());
+        let mut node_port_indices = HashMap::new();
+        self.graph.inputs(idx).zip(inputs).for_each(|(p, input)| {
+            node_port_indices.insert(input.clone(), p);
+            self.port_names.insert(p, input);
+        });
+        self.graph
+            .outputs(idx)
+            .zip(outputs)
+            .for_each(|(p, output)| {
+                node_port_indices.insert(output.clone(), p);
+                self.port_names.insert(p, output);
+            });
+        self.port_indices.insert(idx, node_port_indices);
+        self.node_definitions.insert(idx, node_definition);
+        idx
+    }
+
+    /// Link two nodes together using their port names.
+    ///
+    /// # Errors
+    ///
+    /// Will return Err if the provided `NodeIndex` or Port names are invalid or if the internal
+    /// state of the Workflow graph is invalid or corrupted.
+    pub fn link_nodes_by_port_name(
+        &mut self,
+        from: &NodeIndex,
+        from_output: &str,
+        to: &NodeIndex,
+        to_input: &str,
+    ) -> miette::Result<()> {
+        let res: miette::Result<()> = {
+            let from_port = self
+                .port_indices
+                .get(from)
+                .ok_or_else(|| miette!("Node `from` not found in port indices mapping: {from:?}"))?
+                .get(from_output)
+                .ok_or_else(|| {
+                    miette!("Port `from_output` not found in port indices mapping: {from:?}")
+                })?;
+            let to_port = self
+                .port_indices
+                .get(to)
+                .ok_or_else(|| miette!("Node `to` not found in port indices mapping: {from:?}"))?
+                .get(to_input)
+                .ok_or_else(|| {
+                    miette!("Port `to_input` not found in port indices mapping: {from:?}")
+                })?;
+            self.graph
+                .link_ports(*from_port, *to_port)
+                .into_diagnostic()?;
+            Ok(())
+        };
+        res.wrap_err(miette!(
+            "Failed to link ports {from:?}:{from_output} -> {to:?}:{to_input}"
+        ))
+    }
+
+    /// Returns an iterator of input links from a provided `NodeIndex`.
+    ///
+    /// The links contain the input port on the provided node and the
+    /// output port of the connected node.
+    pub fn input_links(
+        &self,
+        node: NodeIndex,
+    ) -> impl Iterator<Item = (PortIndex, PortIndex)> + Clone {
+        self.graph.input_links(node)
+    }
+
+    /// Returns the name corresponding to a provided `PortIndex`.
+    ///
+    /// # Errors
+    ///
+    /// Will return Err if the provided `PortIndex` is not found in the Graph.
+    pub fn get_port_name(&self, port: &PortIndex) -> miette::Result<&String> {
+        self.port_names
+            .get(port)
+            .ok_or_else(|| miette!("Could not find port name for port id: {port:?}"))
+    }
+
+    /// Returns the `NodeIndex` for a specified `PortIndex`.
+    ///
+    /// # Errors
+    ///
+    /// Will return Err if the provided `PortIndex` is not found in the Graph.
+    pub fn port_node(&self, port: PortIndex) -> miette::Result<NodeIndex> {
+        self.graph
+            .port_node(port)
+            .ok_or_else(|| miette!("Could not find node for port: {port:?}"))
+    }
+
+    /// Apply a function that returns a bool to all the input neighbours of a Node and return true
+    /// if all the returned values are true and false otherwise.
+    pub fn all_inputs(&self, node: NodeIndex, f: impl FnMut(NodeIndex) -> bool) -> bool {
+        self.graph.input_neighbours(node).all(f)
+    }
+
+    /// Return an iterator that returns the `NodeIndex` of Nodes where
+    /// the supplied `filter` function returns `true`, starting at the
+    /// `output_node` of the graph and then in topologically sorted order.
+    pub fn toposort_filtered_from_output_node<'a>(
+        &'a self,
+        filter: impl FnMut(NodeIndex) -> bool + 'a,
+    ) -> TopoSort<'a, &'a PortGraph> {
+        toposort_filtered::<_, BitVec>(
+            &self.graph,
+            [self.output_node],
+            Direction::Incoming,
+            filter,
+            |_, _| true,
+        )
+    }
 }

--- a/tierkreis/src/orchestrator.rs
+++ b/tierkreis/src/orchestrator.rs
@@ -5,7 +5,7 @@ of [Event]s with updates about each node in the Workflow.
 */
 use std::{
     collections::HashMap,
-    sync::{Arc, Mutex},
+    sync::{Arc, LazyLock, Mutex},
 };
 
 use futures::{
@@ -14,6 +14,8 @@ use futures::{
     stream::{BoxStream, select_all},
 };
 use miette::{Context, IntoDiagnostic, miette};
+use portgraph::NodeIndex;
+use serde_json::Value;
 
 use crate::{
     asset_storage::{
@@ -23,8 +25,42 @@ use crate::{
     },
     event::{Event, send_complete},
     executor::{ExecutorRegistry, interface::TaskPlan},
-    graph::Node,
+    graph::{NodeDefinition, WorkflowGraph},
 };
+
+static EMPTY_INPUTS: LazyLock<HashMap<String, AssetSpec>> = LazyLock::new(HashMap::new);
+
+/// [Action] is a placeholder enum for operation the Executor can perform
+/// when interpreting a Workflow graph.
+#[derive(Debug, PartialEq, Eq)]
+pub enum Action {
+    /// An operation performed by a Worker.
+    Task {
+        /// The name of the Worker to call.
+        worker_name: String,
+        /// The name of the Task to call.
+        task_name: String,
+    },
+    /// An input to the Workflow.
+    Input {
+        /// The name of the Workflow input to capture.
+        name: String,
+    },
+    /// The output of the Workflow
+    Output {},
+    /// A constant Value in the Workflow.
+    Const {
+        /// The constant value to return.
+        value: Value,
+    },
+}
+
+#[allow(dead_code)]
+#[derive(Debug)]
+struct ExecutionContext<'a> {
+    graph_inputs: &'a HashMap<String, AssetSpec>,
+    node_outputs: &'a HashMap<NodeIndex, HashMap<String, AssetSpec>>,
+}
 
 /// [Orchestrator] manages the Workflow execution by dispatching [Node]s to the correct
 /// [Executor][crate::executor::Executor] as well as managing a shared [`AssetStorageRegistry`]
@@ -82,110 +118,180 @@ impl Orchestrator {
         })
     }
 
-    /// Dispatch a single [Node] for execution.
+    #[allow(dead_code)]
+    fn build_actions<'a>(
+        &self,
+        context: &'a ExecutionContext<'a>,
+        workflow_graph: &'a WorkflowGraph,
+    ) -> impl Iterator<Item = (Action, HashMap<String, AssetSpec>)> {
+        workflow_graph
+            .toposort_filtered_from_output_node(|n| !context.node_outputs.contains_key(&n))
+            .filter(|n| {
+                workflow_graph
+                    .all_inputs(*n, |incoming| context.node_outputs.contains_key(&incoming))
+            })
+            .flat_map(move |n| {
+                let definition = workflow_graph.node_definition(n).unwrap();
+                match definition {
+                    NodeDefinition::Input { name } => {
+                        vec![(
+                            Action::Input { name: name.clone() },
+                            context.graph_inputs.clone(),
+                        )]
+                    }
+                    NodeDefinition::Const { value } => vec![(
+                        Action::Const {
+                            value: value.clone(),
+                        },
+                        EMPTY_INPUTS.clone(),
+                    )],
+                    NodeDefinition::Output {} => {
+                        let inputs = collect_inputs(context, workflow_graph, n).unwrap();
+                        vec![(Action::Output {}, inputs)]
+                    }
+                    NodeDefinition::Task {
+                        worker_name,
+                        task_name,
+                    } => {
+                        let inputs = collect_inputs(context, workflow_graph, n).unwrap();
+                        vec![(
+                            Action::Task {
+                                worker_name: worker_name.clone(),
+                                task_name: task_name.clone(),
+                            },
+                            inputs,
+                        )]
+                    }
+                    NodeDefinition::Eval {} => {
+                        let inputs = collect_inputs(context, workflow_graph, n).unwrap();
+                        let graph_asset_spec = inputs.get("thunk").unwrap();
+
+                        let asset_storage = self.asset_storage_registry.read().unwrap();
+                        let subgraph_storage =
+                            asset_storage.get(&graph_asset_spec.storage_name).unwrap();
+                        let subgraph_bytes =
+                            subgraph_storage.load(&graph_asset_spec.asset_key).unwrap();
+                        let subgraph: WorkflowGraph =
+                            serde_json::from_slice(&subgraph_bytes).unwrap();
+
+                        self.build_actions(
+                            &ExecutionContext {
+                                graph_inputs: &inputs,
+                                // TODO: We need to get the existing graph state somehow
+                                node_outputs: &HashMap::new(),
+                            },
+                            &subgraph,
+                        )
+                        .collect()
+                    }
+                }
+            })
+    }
+
+    /// Perform a series of actions, dispatching to [`Executor`]s when necessary.
     ///
     /// # Errors
     ///
     /// Will return Err if a Node cannot be run or dispatched.
-    // TODO: This should really be a list of Nodes or similar.
-    pub async fn start_node(
+    pub async fn perform_actions(
         &self,
-        node: &Node,
-        inputs: HashMap<String, AssetSpec>,
+        actions: impl IntoIterator<Item = (Action, HashMap<String, AssetSpec>)>,
     ) -> miette::Result<()> {
-        match node {
-            Node::Task {
-                worker_name,
-                task_name,
-            } => {
-                let task_plans = vec![TaskPlan {
-                    worker_name: worker_name.clone(),
-                    task_name: task_name.clone(),
-
-                    inputs,
-
+        // Build a list of tasks to dispatch to Executors and immediately
+        // process everything else.
+        let mut task_plans = Vec::new();
+        for (action, inputs) in actions {
+            match action {
+                Action::Task {
+                    worker_name,
+                    task_name,
+                } => task_plans.push(TaskPlan {
+                    worker_name,
+                    task_name,
+                    inputs: inputs.clone(),
                     output_storage_name: Some(self.default_storage_name.clone()),
                     ..Default::default()
-                }];
-                let default_executor_name = &self.default_executor_name;
-                let executor = self
-                    .executor_registry
-                    .get(&self.default_executor_name)
-                    .ok_or_else(|| miette!("Could not find a storage with name '{default_executor_name}' in ExecutorRegistry")).wrap_err("Could not run Task Node")?;
-                executor
-                    .execute(task_plans)
-                    .await
-                    .wrap_err("Could not run Task Node")?;
-            }
-            Node::Input { name } => {
-                // Assume the inputs are the inputs to the graph.
-                //
-                // Just pull out the named input and assign it to the "value" output.
-                let value_spec = inputs
-                    .get(name)
-                    .ok_or(miette!("Missing input: {name}"))
-                    .wrap_err("Could not run Input Node")?;
-                let mut outputs = HashMap::new();
-                outputs.insert("value".to_string(), value_spec.clone());
+                }),
+                Action::Input { name } => {
+                    // Assume the inputs are the inputs to the graph.
+                    //
+                    // Just pull out the named input and assign it to the "value" output.
+                    let value_spec = inputs
+                        .get(&name)
+                        .ok_or(miette!("Missing input: {name}"))
+                        .wrap_err("Could not run Input Node")?;
+                    let mut outputs = HashMap::new();
+                    outputs.insert("value".to_string(), value_spec.clone());
 
-                // Move the value into storage if needed.
-                if value_spec.storage_name != self.default_storage_name {
+                    // Move the values if needed.
                     outputs = transfer_assets(
                         &self.asset_storage_registry,
                         &self.default_storage_name,
                         &outputs,
                     )?;
+
+                    let mut event_sender = self.event_sender.clone();
+                    send_complete(&mut event_sender, 0, outputs).await?;
                 }
+                Action::Output {} => {
+                    // Notify that the outputs are ready
+                    let mut event_sender = self.event_sender.clone();
 
-                let mut event_sender = self.event_sender.clone();
-                send_complete(&mut event_sender, 0, outputs).await?;
-            }
-            Node::Output {} => {
-                // Notify that the outputs are ready
-                let mut event_sender = self.event_sender.clone();
-
-                let outputs = transfer_assets(
-                    &self.asset_storage_registry,
-                    &self.default_storage_name,
-                    &inputs,
-                )
-                .wrap_err("Could not run Output Node")?;
-                send_complete(&mut event_sender, 0, outputs).await?;
-            }
-            Node::Const { value } => {
-                // Load the constant value into the correct storage.
-                let outputs = {
-                    let asset_storage_registry_lock =
-                        self.asset_storage_registry.read().map_err(|err| {
-                            miette!("Failed to lock AssetStorageRegistry for reading: {err}")
-                        })?;
-                    let default_storage_name = &self.default_storage_name;
-                    let asset_storage = asset_storage_registry_lock
+                    // Move the values if needed.
+                    let outputs = transfer_assets(
+                        &self.asset_storage_registry,
+                        &self.default_storage_name,
+                        &inputs,
+                    )
+                    .wrap_err("Could not run Output Node")?;
+                    send_complete(&mut event_sender, 0, outputs).await?;
+                }
+                Action::Const { value } => {
+                    // Load the constant value into the correct storage.
+                    //
+                    // `outputs` is explicitly scoped to manage the lifetime of the
+                    // `asset_storage_registry_lock` to avoid holding it across an `await`.
+                    let outputs = {
+                        let asset_storage_registry_lock =
+                            self.asset_storage_registry.read().map_err(|err| {
+                                miette!("Failed to lock AssetStorageRegistry for reading: {err}")
+                            })?;
+                        let default_storage_name = &self.default_storage_name;
+                        let asset_storage = asset_storage_registry_lock
                     .get(default_storage_name)
                     .ok_or_else(|| miette!("Could not find a storage with name '{default_storage_name}' in AssetStorageRegistry"))?;
-                    let asset_key = AssetKey::new();
-                    asset_storage
-                        .save(&asset_key, serde_json::to_vec(&value).into_diagnostic()?)?;
+                        let asset_key = AssetKey::new();
+                        asset_storage
+                            .save(&asset_key, serde_json::to_vec(&value).into_diagnostic()?)?;
 
-                    let mut outputs = HashMap::new();
-                    outputs.insert(
-                        "value".to_string(),
-                        AssetSpec {
-                            kind: asset_storage.kind(),
-                            storage_name: self.default_storage_name.clone(),
-                            asset_key,
-                        },
-                    );
-                    outputs
-                };
+                        let mut outputs = HashMap::new();
+                        outputs.insert(
+                            "value".to_string(),
+                            AssetSpec {
+                                kind: asset_storage.kind(),
+                                storage_name: self.default_storage_name.clone(),
+                                asset_key,
+                            },
+                        );
 
-                let mut event_sender = self.event_sender.clone();
-                send_complete(&mut event_sender, 0, outputs).await?;
-            }
-            Node::Eval {} => {
-                // spawn a sub-orchestrator?
+                        outputs
+                    };
+
+                    let mut event_sender = self.event_sender.clone();
+                    send_complete(&mut event_sender, 0, outputs).await?;
+                }
             }
         }
+
+        let default_executor_name = &self.default_executor_name;
+        let executor = self
+            .executor_registry
+            .get(default_executor_name)
+            .ok_or_else(|| miette!("Could not find a storage with name '{default_executor_name}' in ExecutorRegistry")).wrap_err("Could not run Task Nodes")?;
+        executor
+            .execute(task_plans)
+            .await
+            .wrap_err("Could not run Task Nodes")?;
 
         Ok(())
     }
@@ -223,6 +329,30 @@ impl Orchestrator {
         streams.push(orchestrator_events.boxed());
         Ok(select_all(streams).boxed())
     }
+}
+
+fn collect_inputs(
+    context: &ExecutionContext<'_>,
+    workflow_graph: &WorkflowGraph,
+    n: NodeIndex,
+) -> miette::Result<HashMap<String, AssetSpec>> {
+    let inputs: HashMap<String, AssetSpec> = workflow_graph
+        .input_links(n)
+        .map(|(i, o)| {
+            let input_name = workflow_graph.get_port_name(&i)?;
+            let output_name = workflow_graph.get_port_name(&o)?;
+            let linked_node = workflow_graph.port_node(o)?;
+            let output_asset_spec = context
+                .node_outputs
+                .get(&linked_node)
+                .ok_or_else(|| miette!("Could not find node outputs for node: {linked_node:?}"))?
+                .get(output_name)
+                .ok_or_else(|| miette!("Could not get node output for node: {linked_node:?} and port name: {output_name}"))?;
+            Ok((input_name.clone(), output_asset_spec.clone()))
+        })
+        .collect::<miette::Result<_>>()
+        .wrap_err(miette!("Could not collect inputs for node with id: {n:?}"))?;
+    Ok(inputs)
 }
 
 #[cfg(test)]
@@ -273,12 +403,12 @@ mod tests {
         )?;
         let stream = orchestrator.listen()?;
 
-        let node = &Node::Task {
+        let node = Action::Task {
             worker_name: "builtin".to_string(),
             task_name: "iadd".to_string(),
         };
         let inputs = input_sets[0].clone();
-        orchestrator.start_node(node, inputs).await?;
+        orchestrator.perform_actions([(node, inputs)]).await?;
 
         let events = stream.take(2).collect::<Vec<_>>().await;
         assert_eq!(events.len(), 2);
@@ -310,17 +440,17 @@ mod tests {
         )?;
         let stream = orchestrator.listen()?;
 
-        let node = &Node::Input {
+        let node = Action::Input {
             name: "a".to_string(),
         };
         let inputs = input_sets[0].clone();
-        orchestrator.start_node(node, inputs).await?;
+        orchestrator.perform_actions([(node, inputs)]).await?;
 
-        let node = &Node::Input {
+        let node = Action::Input {
             name: "b".to_string(),
         };
         let inputs = input_sets[0].clone();
-        orchestrator.start_node(node, inputs).await?;
+        orchestrator.perform_actions([(node, inputs)]).await?;
 
         let events = stream.take(2).collect::<Vec<_>>().await;
         assert_eq!(events.len(), 2);
@@ -357,9 +487,9 @@ mod tests {
         )?;
         let stream = orchestrator.listen()?;
 
-        let node = &Node::Output {};
+        let node = Action::Output {};
         let inputs = input_sets[0].clone();
-        orchestrator.start_node(node, inputs).await?;
+        orchestrator.perform_actions([(node, inputs)]).await?;
 
         let events = stream.take(1).collect::<Vec<_>>().await;
         assert_eq!(events.len(), 1);
@@ -389,11 +519,11 @@ mod tests {
         )?;
         let stream = orchestrator.listen()?;
 
-        let node = &Node::Const {
+        let node = Action::Const {
             value: "hello there".into(),
         };
         let inputs = HashMap::new();
-        orchestrator.start_node(node, inputs).await?;
+        orchestrator.perform_actions([(node, inputs)]).await?;
 
         let events = stream.take(1).collect::<Vec<_>>().await;
         assert_eq!(events.len(), 1);
@@ -413,7 +543,7 @@ mod tests {
     #[case("memory")]
     #[case("file")]
     #[tokio::test]
-    async fn start_simple_workflow(#[case] default_storage_name: &str) -> miette::Result<()> {
+    async fn perform_simple_workflow(#[case] default_storage_name: &str) -> miette::Result<()> {
         let (registry, input_sets, _dir) = test_storage_registry(vec![json!({"a": 1})], vec![]);
         let executor_registry = test_executor_registry(&registry);
         let orchestrator = Orchestrator::try_new(
@@ -424,11 +554,11 @@ mod tests {
         )?;
         let mut stream = orchestrator.listen()?;
 
-        let node = &Node::Input {
+        let node = Action::Input {
             name: "a".to_string(),
         };
         let inputs = input_sets[0].clone();
-        orchestrator.start_node(node, inputs).await?;
+        orchestrator.perform_actions([(node, inputs)]).await?;
 
         let input_complete_event = stream.next().await.unwrap();
         dbg!(&input_complete_event);
@@ -440,9 +570,9 @@ mod tests {
             json!({"value": 1}),
         );
 
-        let node = &Node::Const { value: 3.into() };
+        let node = Action::Const { value: 3.into() };
         let inputs = HashMap::new();
-        orchestrator.start_node(node, inputs).await?;
+        orchestrator.perform_actions([(node, inputs)]).await?;
 
         let const_complete_event = stream.next().await.unwrap();
         dbg!(&const_complete_event);
@@ -454,7 +584,7 @@ mod tests {
             json!({"value": 3}),
         );
 
-        let node = &Node::Task {
+        let node = Action::Task {
             worker_name: "builtin".to_string(),
             task_name: "iadd".to_string(),
         };
@@ -467,7 +597,7 @@ mod tests {
             "b".to_string(),
             const_complete_outputs.remove("value").unwrap(),
         );
-        orchestrator.start_node(node, inputs).await?;
+        orchestrator.perform_actions([(node, inputs)]).await?;
 
         let task_running_event = stream.next().await.unwrap();
         dbg!(&task_running_event);
@@ -482,13 +612,13 @@ mod tests {
             json!({"value": 4}),
         );
 
-        let node = &Node::Output {};
+        let node = Action::Output {};
         let mut inputs = HashMap::new();
         inputs.insert(
             "value".to_string(),
             task_complete_outputs.remove("value").unwrap(),
         );
-        orchestrator.start_node(node, inputs).await?;
+        orchestrator.perform_actions([(node, inputs)]).await?;
 
         let output_complete_event = stream.next().await.unwrap();
         dbg!(&output_complete_event);
@@ -498,6 +628,156 @@ mod tests {
             &orchestrator.default_storage_name,
             &output_complete_outputs,
             json!({"value": 4}),
+        );
+
+        Ok(())
+    }
+
+    // Test that we can plan a workflow with two input nodes.
+    #[rstest]
+    #[case("memory")]
+    #[case("file")]
+    #[tokio::test]
+    async fn plan_two_input_workflow(#[case] default_storage_name: &str) -> miette::Result<()> {
+        let (registry, input_sets, _dir) =
+            test_storage_registry(vec![json!({"a": 1, "b": 4})], vec![]);
+        let executor_registry = test_executor_registry(&registry);
+        let orchestrator = Orchestrator::try_new(
+            &registry,
+            &executor_registry,
+            default_storage_name,
+            "memory",
+        )?;
+
+        let mut workflow_graph = WorkflowGraph::new(["out1".to_string(), "out2".to_string()]);
+        let input1_idx = workflow_graph.add_node(
+            NodeDefinition::Input {
+                name: "a".to_string(),
+            },
+            [],
+            ["value".to_string()],
+        );
+        workflow_graph
+            .link_nodes_by_port_name(&input1_idx, "value", &workflow_graph.output_idx(), "out1")
+            .unwrap();
+        let input2_idx = workflow_graph.add_node(
+            NodeDefinition::Input {
+                name: "b".to_string(),
+            },
+            [],
+            ["value".to_string()],
+        );
+        workflow_graph
+            .link_nodes_by_port_name(&input2_idx, "value", &workflow_graph.output_idx(), "out2")
+            .unwrap();
+        dbg!(&workflow_graph);
+
+        let inputs = input_sets[0].clone();
+        let context = &ExecutionContext {
+            graph_inputs: &inputs.clone(),
+            node_outputs: &HashMap::new(),
+        };
+        let actions = orchestrator.build_actions(context, &workflow_graph);
+        let actions = actions.collect::<Vec<_>>();
+
+        assert_eq!(actions.len(), 2);
+        assert_eq!(
+            actions[0].0,
+            Action::Input {
+                name: "a".to_string()
+            }
+        );
+        assert_eq!(
+            actions[1].0,
+            Action::Input {
+                name: "b".to_string()
+            }
+        );
+
+        Ok(())
+    }
+
+    // Test that we can plan the first actions of a workflow and run them.
+    #[rstest]
+    #[case("memory")]
+    #[case("file")]
+    #[tokio::test]
+    async fn plan_and_run_simple_io_workflow(
+        #[case] default_storage_name: &str,
+    ) -> miette::Result<()> {
+        let (registry, input_sets, _dir) = test_storage_registry(vec![json!({"a": 1})], vec![]);
+        let executor_registry = test_executor_registry(&registry);
+        let orchestrator = Orchestrator::try_new(
+            &registry,
+            &executor_registry,
+            default_storage_name,
+            "memory",
+        )?;
+        let mut stream = orchestrator.listen()?;
+
+        let mut workflow_graph = WorkflowGraph::new(["out".to_string()]);
+        let input_idx = workflow_graph.add_node(
+            NodeDefinition::Input {
+                name: "a".to_string(),
+            },
+            [],
+            ["value".to_string()],
+        );
+
+        workflow_graph
+            .link_nodes_by_port_name(&input_idx, "value", &workflow_graph.output_idx(), "out")
+            .unwrap();
+        dbg!(&workflow_graph);
+
+        let inputs = input_sets[0].clone();
+        let context = &ExecutionContext {
+            graph_inputs: &inputs.clone(),
+            node_outputs: &HashMap::new(),
+        };
+        let actions = orchestrator.build_actions(context, &workflow_graph);
+        let actions = actions.collect::<Vec<_>>();
+
+        assert_eq!(actions.len(), 1);
+        assert_eq!(
+            actions[0].0,
+            Action::Input {
+                name: "a".to_string()
+            }
+        );
+
+        orchestrator.perform_actions(actions).await?;
+        let input_complete_event = stream.next().await.unwrap();
+        dbg!(&input_complete_event);
+        let input_complete_outputs = input_complete_event.outputs().unwrap();
+        assert_registry_contains_values(
+            &registry,
+            &orchestrator.default_storage_name,
+            &input_complete_outputs,
+            json!({"value": 1}),
+        );
+
+        let mut node_outputs = HashMap::new();
+        node_outputs.insert(input_idx, input_complete_outputs);
+        let context = &ExecutionContext {
+            graph_inputs: &inputs.clone(),
+            node_outputs: &node_outputs,
+        };
+
+        let actions = orchestrator.build_actions(context, &workflow_graph);
+        let actions = actions.collect::<Vec<_>>();
+
+        assert_eq!(actions.len(), 1);
+        assert_eq!(actions[0].0, Action::Output {});
+
+        orchestrator.perform_actions(actions).await?;
+        let output_complete_event = stream.next().await.unwrap();
+        dbg!(&output_complete_event);
+        let output_complete_outputs = output_complete_event.outputs().unwrap();
+        assert_registry_contains_values(
+            &registry,
+            &orchestrator.default_storage_name,
+            &output_complete_outputs,
+            json!({"out": 1}),
         );
 
         Ok(())

--- a/tierkreis/src/orchestrator.rs
+++ b/tierkreis/src/orchestrator.rs
@@ -35,21 +35,21 @@ static EMPTY_INPUTS: LazyLock<HashMap<String, AssetSpec>> = LazyLock::new(HashMa
 #[derive(Debug, PartialEq, Eq)]
 pub enum Action {
     /// An operation performed by a Worker.
-    Task {
+    PerformTask {
         /// The name of the Worker to call.
         worker_name: String,
         /// The name of the Task to call.
         task_name: String,
     },
     /// An input to the Workflow.
-    Input {
+    LoadInput {
         /// The name of the Workflow input to capture.
         name: String,
     },
     /// The output of the Workflow
-    Output {},
+    NotifyOutput {},
     /// A constant Value in the Workflow.
-    Const {
+    LoadConst {
         /// The constant value to return.
         value: Value,
     },
@@ -135,19 +135,19 @@ impl Orchestrator {
                 match definition {
                     NodeDefinition::Input { name } => {
                         vec![(
-                            Action::Input { name: name.clone() },
+                            Action::LoadInput { name: name.clone() },
                             context.graph_inputs.clone(),
                         )]
                     }
                     NodeDefinition::Const { value } => vec![(
-                        Action::Const {
+                        Action::LoadConst {
                             value: value.clone(),
                         },
                         EMPTY_INPUTS.clone(),
                     )],
                     NodeDefinition::Output {} => {
                         let inputs = collect_inputs(context, workflow_graph, n).unwrap();
-                        vec![(Action::Output {}, inputs)]
+                        vec![(Action::NotifyOutput {}, inputs)]
                     }
                     NodeDefinition::Task {
                         worker_name,
@@ -155,7 +155,7 @@ impl Orchestrator {
                     } => {
                         let inputs = collect_inputs(context, workflow_graph, n).unwrap();
                         vec![(
-                            Action::Task {
+                            Action::PerformTask {
                                 worker_name: worker_name.clone(),
                                 task_name: task_name.clone(),
                             },
@@ -164,7 +164,7 @@ impl Orchestrator {
                     }
                     NodeDefinition::Eval {} => {
                         let inputs = collect_inputs(context, workflow_graph, n).unwrap();
-                        let graph_asset_spec = inputs.get("thunk").unwrap();
+                        let graph_asset_spec = inputs.get("graph").unwrap();
 
                         let asset_storage = self.asset_storage_registry.read().unwrap();
                         let subgraph_storage =
@@ -202,7 +202,7 @@ impl Orchestrator {
         let mut task_plans = Vec::new();
         for (action, inputs) in actions {
             match action {
-                Action::Task {
+                Action::PerformTask {
                     worker_name,
                     task_name,
                 } => task_plans.push(TaskPlan {
@@ -212,7 +212,7 @@ impl Orchestrator {
                     output_storage_name: Some(self.default_storage_name.clone()),
                     ..Default::default()
                 }),
-                Action::Input { name } => {
+                Action::LoadInput { name } => {
                     // Assume the inputs are the inputs to the graph.
                     //
                     // Just pull out the named input and assign it to the "value" output.
@@ -233,7 +233,7 @@ impl Orchestrator {
                     let mut event_sender = self.event_sender.clone();
                     send_complete(&mut event_sender, 0, outputs).await?;
                 }
-                Action::Output {} => {
+                Action::NotifyOutput {} => {
                     // Notify that the outputs are ready
                     let mut event_sender = self.event_sender.clone();
 
@@ -246,7 +246,7 @@ impl Orchestrator {
                     .wrap_err("Could not run Output Node")?;
                     send_complete(&mut event_sender, 0, outputs).await?;
                 }
-                Action::Const { value } => {
+                Action::LoadConst { value } => {
                     // Load the constant value into the correct storage.
                     //
                     // `outputs` is explicitly scoped to manage the lifetime of the
@@ -403,7 +403,7 @@ mod tests {
         )?;
         let stream = orchestrator.listen()?;
 
-        let node = Action::Task {
+        let node = Action::PerformTask {
             worker_name: "builtin".to_string(),
             task_name: "iadd".to_string(),
         };
@@ -440,13 +440,13 @@ mod tests {
         )?;
         let stream = orchestrator.listen()?;
 
-        let node = Action::Input {
+        let node = Action::LoadInput {
             name: "a".to_string(),
         };
         let inputs = input_sets[0].clone();
         orchestrator.perform_actions([(node, inputs)]).await?;
 
-        let node = Action::Input {
+        let node = Action::LoadInput {
             name: "b".to_string(),
         };
         let inputs = input_sets[0].clone();
@@ -487,7 +487,7 @@ mod tests {
         )?;
         let stream = orchestrator.listen()?;
 
-        let node = Action::Output {};
+        let node = Action::NotifyOutput {};
         let inputs = input_sets[0].clone();
         orchestrator.perform_actions([(node, inputs)]).await?;
 
@@ -519,7 +519,7 @@ mod tests {
         )?;
         let stream = orchestrator.listen()?;
 
-        let node = Action::Const {
+        let node = Action::LoadConst {
             value: "hello there".into(),
         };
         let inputs = HashMap::new();
@@ -554,7 +554,7 @@ mod tests {
         )?;
         let mut stream = orchestrator.listen()?;
 
-        let node = Action::Input {
+        let node = Action::LoadInput {
             name: "a".to_string(),
         };
         let inputs = input_sets[0].clone();
@@ -570,7 +570,7 @@ mod tests {
             json!({"value": 1}),
         );
 
-        let node = Action::Const { value: 3.into() };
+        let node = Action::LoadConst { value: 3.into() };
         let inputs = HashMap::new();
         orchestrator.perform_actions([(node, inputs)]).await?;
 
@@ -584,7 +584,7 @@ mod tests {
             json!({"value": 3}),
         );
 
-        let node = Action::Task {
+        let node = Action::PerformTask {
             worker_name: "builtin".to_string(),
             task_name: "iadd".to_string(),
         };
@@ -612,7 +612,7 @@ mod tests {
             json!({"value": 4}),
         );
 
-        let node = Action::Output {};
+        let node = Action::NotifyOutput {};
         let mut inputs = HashMap::new();
         inputs.insert(
             "value".to_string(),
@@ -683,13 +683,13 @@ mod tests {
         assert_eq!(actions.len(), 2);
         assert_eq!(
             actions[0].0,
-            Action::Input {
+            Action::LoadInput {
                 name: "a".to_string()
             }
         );
         assert_eq!(
             actions[1].0,
-            Action::Input {
+            Action::LoadInput {
                 name: "b".to_string()
             }
         );
@@ -740,7 +740,7 @@ mod tests {
         assert_eq!(actions.len(), 1);
         assert_eq!(
             actions[0].0,
-            Action::Input {
+            Action::LoadInput {
                 name: "a".to_string()
             }
         );
@@ -767,7 +767,7 @@ mod tests {
         let actions = actions.collect::<Vec<_>>();
 
         assert_eq!(actions.len(), 1);
-        assert_eq!(actions[0].0, Action::Output {});
+        assert_eq!(actions[0].0, Action::NotifyOutput {});
 
         orchestrator.perform_actions(actions).await?;
         let output_complete_event = stream.next().await.unwrap();


### PR DESCRIPTION
* Split Node into Action and NodeDefinition that describe an action
the Orchestrator has to perform versus the definition of a Node in
the graph.
* Add a new WorkflowGraph type that can be evaluated to find Nodes
to run.
* Add a new Execution Context that can be used with the WorkflowGraph
to plan a series of Actions.