### PR TITLE
chore: Refactor Executors and Events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -912,12 +912,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lazy_static"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1782,7 +1776,6 @@ dependencies = [
  "clap",
  "dashmap",
  "futures",
- "lazy_static",
  "miette",
  "pyo3",
  "regex",

--- a/devenv.lock
+++ b/devenv.lock
@@ -97,6 +97,9 @@
         "devenv": "devenv",
         "git-hooks": "git-hooks",
         "nixpkgs": "nixpkgs",
+        "pre-commit-hooks": [
+          "git-hooks"
+        ],
         "rust-overlay": "rust-overlay"
       }
     },

--- a/tierkreis/Cargo.toml
+++ b/tierkreis/Cargo.toml
@@ -14,9 +14,8 @@ chrono = { version = "0.4.44", features = ["serde"] }
 clap = { version = "4.6.0", features = ["derive"] }
 dashmap = "6.1.0"
 futures = "0.3.32"
-lazy_static = "1.5.0"
 miette = { version = "7.6.0", features = ["fancy", "syntect-highlighter"] }
-pyo3 = { version = "0.28.2", features = ["auto-initialize", "anyhow"] }
+pyo3 = { version = "0.28.2", features = ["auto-initialize", "anyhow", "abi3"] }
 regex = "1.12.3"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"

--- a/tierkreis/src/asset_storage.rs
+++ b/tierkreis/src/asset_storage.rs
@@ -36,20 +36,20 @@ pub type AssetStorageRegistry = Arc<RwLock<HashMap<String, Box<dyn AssetStorage>
 /// an [`AssetStorage`] with the specified name does not exist in the registry.
 pub fn load_inputs<S: BuildHasher>(
     registry: &AssetStorageRegistry,
-    inputs: HashMap<String, AssetSpec, S>,
+    inputs: &HashMap<String, AssetSpec, S>,
 ) -> miette::Result<HashMap<String, Vec<u8>>> {
     let registry = registry
         .read()
         .map_err(|err| miette!("Failed to read AssetStorageRegistry: {err}"))?;
     inputs
-        .into_iter()
+        .iter()
         .map(|(k, v)| {
             let storage_name = &v.storage_name;
             let storage = registry.get(storage_name).ok_or(miette!(
                 "Cannot find AssetStorage in AssetStorageRegistry with name: {storage_name}"
             ))?;
             let asset = storage.load(&v.asset_key)?;
-            Ok((k, asset))
+            Ok((k.clone(), asset))
         })
         .collect()
 }
@@ -102,7 +102,7 @@ pub fn save_outputs<S: BuildHasher>(
 pub fn transfer_assets<S: BuildHasher>(
     registry: &AssetStorageRegistry,
     storage_name_to: &str,
-    assets_from: HashMap<String, AssetSpec, S>,
+    assets_from: &HashMap<String, AssetSpec, S>,
 ) -> miette::Result<HashMap<String, AssetSpec>> {
     let registry = registry
         .read()
@@ -112,10 +112,10 @@ pub fn transfer_assets<S: BuildHasher>(
     ))?;
 
     assets_from
-        .into_iter()
+        .iter()
         .map(|(k, v)| {
             if v.storage_name == storage_name_to {
-                Ok((k, v))
+                Ok((k.clone(), v.clone()))
             } else {
                 let storage_name_from = &v.storage_name;
                 let storage_from = registry.get(storage_name_from).ok_or(miette!(
@@ -127,7 +127,7 @@ pub fn transfer_assets<S: BuildHasher>(
                 let asset_key = AssetKey::new();
                 storage_to.save(&asset_key, asset)?;
                 Ok((
-                    k,
+                    k.clone(),
                     AssetSpec {
                         kind: storage_to.kind(),
                         asset_key,

--- a/tierkreis/src/event.rs
+++ b/tierkreis/src/event.rs
@@ -5,7 +5,8 @@ state of the Workflow so it can be monitored and restarted.
 */
 use std::{collections::HashMap, hash::RandomState};
 
-use futures::channel::mpsc;
+use futures::{SinkExt, channel::mpsc};
+use miette::miette;
 
 use crate::asset_storage::interface::AssetSpec;
 
@@ -80,63 +81,71 @@ pub type EventReceiver = mpsc::Receiver<Event>;
 
 /// Utility function to send a new [`Event`] with [`Status::Running`].
 ///
-/// # Panics
+/// # Errors
 ///
-/// Will panic if the channel is full or disconnected.
-pub fn send_running(event_sender: &mut EventSender, id: u32) {
+/// Will return Err if the channel for `event_sender` is full or closed.
+pub async fn send_running(event_sender: &mut EventSender, id: u32) -> miette::Result<()> {
     event_sender
-        .try_send(Event {
+        .send(Event {
             id,
             status: Status::Running {},
         })
-        .expect("Failed to send update");
+        .await
+        .map_err(|err| miette!("Failed to send running event: {err}"))
 }
 
 /// Utility function to send a new [`Event`] with [`Status::Cancelled`].
 ///
-/// # Panics
+/// # Errors
 ///
-/// Will panic if the channel is full or disconnected.
-pub fn send_cancelled(event_sender: &mut EventSender, id: u32) {
+/// Will return Err if the channel for `event_sender` is full or closed.
+pub async fn send_cancelled(event_sender: &mut EventSender, id: u32) -> miette::Result<()> {
     event_sender
-        .try_send(Event {
+        .send(Event {
             id,
             status: Status::Cancelled {},
         })
-        .expect("Failed to send update");
+        .await
+        .map_err(|err| miette!("Failed to send cancelled event: {err}"))
 }
 
 /// Utility function to send a new [`Event`] with [`Status::Complete`] and output [`AssetSpec`]s.
 ///
-/// # Panics
+/// # Errors
 ///
-/// Will panic if the channel is full or disconnected.
-pub fn send_complete(
+/// Will return Err if the channel for `event_sender` is full or closed.
+pub async fn send_complete(
     event_sender: &mut EventSender,
     id: u32,
     outputs: HashMap<String, AssetSpec, RandomState>,
-) {
+) -> miette::Result<()> {
     event_sender
-        .try_send(Event {
+        .send(Event {
             id,
             status: Status::Complete { outputs },
         })
-        .expect("Failed to send update");
+        .await
+        .map_err(|err| miette!("Failed to send complete event: {err}"))
 }
 
 /// Utility function to send a new [`Event`] with [`Status::Error`] and an error message.
 ///
-/// # Panics
+/// # Errors
 ///
-/// Will panic if the channel is full or disconnected.
-pub fn send_error(event_sender: &mut EventSender, id: u32, err: &miette::Error) {
+/// Will return Err if the channel for `event_sender` is full or closed.
+pub async fn send_error(
+    event_sender: &mut EventSender,
+    id: u32,
+    err: &miette::Error,
+) -> miette::Result<()> {
     event_sender
-        .try_send(Event {
+        .send(Event {
             id,
             status: Status::Error {
                 error: err.to_string(),
                 detail: None,
             },
         })
-        .expect("Failed to send update");
+        .await
+        .map_err(|err| miette!("Failed to send error event: {err}"))
 }

--- a/tierkreis/src/executor/inmemory.rs
+++ b/tierkreis/src/executor/inmemory.rs
@@ -13,9 +13,9 @@ use std::{
 };
 
 use futures::{
-    FutureExt, StreamExt,
+    FutureExt, SinkExt, StreamExt,
     channel::mpsc,
-    future::{self, BoxFuture},
+    future::BoxFuture,
     stream::{BoxStream, FuturesUnordered},
 };
 use miette::{IntoDiagnostic, miette};
@@ -39,8 +39,20 @@ pub struct InMemoryResourceSpec {}
 #[derive(Clone, Debug, PartialEq, Default)]
 pub struct InMemoryEnvironmentSpec {}
 
-type TaskSender = mpsc::Sender<(u32, TaskPlan, String)>;
-type TaskReceiver = mpsc::Receiver<(u32, TaskPlan, String)>;
+struct BackgroundTaskPlan {
+    id: u32,
+    task_plan: TaskPlan,
+    output_storage_name: String,
+}
+
+struct BackgroundTask {
+    id: u32,
+    output_storage_name: String,
+    task_output: miette::Result<HashMap<String, Vec<u8>>>,
+}
+
+type TaskSender = mpsc::Sender<BackgroundTaskPlan>;
+type TaskReceiver = mpsc::Receiver<BackgroundTaskPlan>;
 type EventSender = mpsc::Sender<Event>;
 type EventReceiver = mpsc::Receiver<Event>;
 type CancelSender = mpsc::Sender<u32>;
@@ -117,8 +129,85 @@ fn run_builtin(
     Ok(outputs)
 }
 
-type RunningFutures =
-    FuturesUnordered<JoinHandle<(u32, String, Result<HashMap<String, Vec<u8>>, miette::Error>)>>;
+type RunningFutures = FuturesUnordered<JoinHandle<BackgroundTask>>;
+
+async fn process_cancelled_task(
+    event_sender: &mut EventSender,
+    abort_handles: &mut HashMap<u32, AbortHandle>,
+    id: u32,
+) -> miette::Result<()> {
+    let handle = abort_handles.remove(&id);
+    if let Some(handle) = handle {
+        handle.abort();
+        send_cancelled(event_sender, id).await?;
+    }
+    Ok(())
+}
+
+async fn process_finished_task(
+    event_sender: &mut EventSender,
+    abort_handles: &mut HashMap<u32, AbortHandle>,
+    asset_storage_registry: &AssetStorageRegistry,
+    background_task: BackgroundTask,
+) -> miette::Result<()> {
+    let id = background_task.id;
+    let task_outputs = background_task.task_output;
+    let output_storage_name = background_task.output_storage_name;
+    abort_handles.remove(&id);
+
+    let outputs = match task_outputs {
+        Ok(outputs) => outputs,
+        Err(err) => {
+            send_error(event_sender, id, &err).await?;
+            return Ok(());
+        }
+    };
+    let outputs = save_outputs(asset_storage_registry, &output_storage_name, outputs);
+    match outputs {
+        Ok(outputs) => send_complete(event_sender, id, outputs).await?,
+        Err(err) => send_error(event_sender, id, &err).await?,
+    }
+
+    Ok(())
+}
+
+async fn start_task(
+    event_sender: &mut EventSender,
+    abort_handles: &mut HashMap<u32, AbortHandle>,
+    asset_storage_registry: &AssetStorageRegistry,
+    running: &mut RunningFutures,
+    internal_task: BackgroundTaskPlan,
+) -> miette::Result<()> {
+    let id = internal_task.id;
+    let task_plan = internal_task.task_plan;
+    let output_storage_name = internal_task.output_storage_name;
+    send_running(event_sender, id).await?;
+
+    let res = load_inputs(asset_storage_registry, &task_plan.inputs);
+
+    let inputs = match res {
+        Ok(inputs) => inputs,
+        Err(err) => {
+            send_error(event_sender, id, &err).await?;
+            return Ok(());
+        }
+    };
+
+    let task = tokio::task::spawn_blocking(move || {
+        let inputs = inputs;
+        let task_name = task_plan.task_name;
+        BackgroundTask {
+            id,
+            output_storage_name,
+            task_output: run_builtin(&task_name, &inputs),
+        }
+    });
+
+    abort_handles.insert(id, task.abort_handle());
+    running.push(task);
+
+    Ok(())
+}
 
 async fn process_tasks(
     mut task_receiver: TaskReceiver,
@@ -133,56 +222,37 @@ async fn process_tasks(
         tokio::select! {
             // A task has been cancelled
             Some(id) = cancel_receiver.next() => {
-                let handle = abort_handles.remove(&id);
-                if let Some(handle) = handle {
-                    handle.abort();
-                    send_cancelled(&mut event_sender, id);
-                }
+                process_cancelled_task(&mut event_sender, &mut abort_handles, id)
+                    .await
+                    .expect("Failed to cancel task");
             }
             // A task has completed
             Some(res) = running.next() => {
-                let (id, output_storage_name, outputs) = match res {
+                let background_task = match res {
                     Ok(ok) => ok,
                     Err(err) => panic!("Failed to join to future: {err}"),
                 };
 
-                abort_handles.remove(&id);
-
-                let outputs = match outputs {
-                    Ok(outputs) => outputs,
-                    Err(err) => {
-                        send_error(&mut event_sender, id, &err);
-                        continue;
-                    }
-                };
-                let outputs = save_outputs(&asset_storage_registry, &output_storage_name, outputs);
-                match outputs {
-                    Ok(outputs) => send_complete(&mut event_sender, id, outputs),
-                    Err(err) => send_error(&mut event_sender, id, &err),
-                }
+                process_finished_task(
+                    &mut event_sender,
+                    &mut abort_handles,
+                    &asset_storage_registry,
+                    background_task,
+                )
+                .await
+                .expect("Failed to complete task");
             }
             // A task has been submitted
-            Some((id, task_plan, output_storage_name)) = task_receiver.next() => {
-                send_running(&mut event_sender, id);
-
-                let res = load_inputs(&asset_storage_registry, task_plan.inputs);
-
-                let inputs = match res {
-                    Ok(inputs) => inputs,
-                    Err(err) => {
-                        send_error(&mut event_sender, id, &err);
-                        continue;
-                    }
-                };
-
-                let task = tokio::task::spawn_blocking(move || {
-                    let inputs = inputs;
-                    let task_name = task_plan.task_name;
-                    (id, output_storage_name, run_builtin(&task_name, &inputs))
-                });
-
-                abort_handles.insert(id, task.abort_handle());
-                running.push(task);
+            Some(internal_task) = task_receiver.next() => {
+                start_task(
+                    &mut event_sender,
+                    &mut abort_handles,
+                    &asset_storage_registry,
+                    &mut running,
+                    internal_task,
+                )
+                .await
+                .expect("Failed to start task");
             }
         }
     }
@@ -253,7 +323,7 @@ impl Executor for InMemoryExecutor {
     }
 
     fn execute(&self, task_plans: Vec<TaskPlan>) -> BoxFuture<'_, miette::Result<Vec<u32>>> {
-        let res = || {
+        let fut = async {
             let mut ids = Vec::new();
             let mut task_sender = self.task_sender.clone();
 
@@ -265,7 +335,12 @@ impl Executor for InMemoryExecutor {
                     .unwrap_or_else(|| self.output_storage_name.clone());
 
                 task_sender
-                    .try_send((id, task_plan, output_storage_name))
+                    .send(BackgroundTaskPlan {
+                        id,
+                        task_plan,
+                        output_storage_name,
+                    })
+                    .await
                     .into_diagnostic()?;
 
                 ids.push(id);
@@ -273,7 +348,7 @@ impl Executor for InMemoryExecutor {
             Ok(ids)
         };
 
-        future::ready(res()).boxed()
+        fut.boxed()
     }
 
     fn listen(&self) -> miette::Result<BoxStream<'_, Event>> {
@@ -292,12 +367,15 @@ impl Executor for InMemoryExecutor {
         Ok(channel.boxed())
     }
 
-    fn cancel(&self, task_ids: Vec<u32>) -> miette::Result<()> {
-        let mut cancel_sender = self.cancel_sender.clone();
-        for task_id in task_ids {
-            cancel_sender.try_send(task_id).into_diagnostic()?;
-        }
-        Ok(())
+    fn cancel(&self, task_ids: Vec<u32>) -> BoxFuture<'_, miette::Result<()>> {
+        let fut = async {
+            let mut cancel_sender = self.cancel_sender.clone();
+            for task_id in task_ids {
+                cancel_sender.send(task_id).await.into_diagnostic()?;
+            }
+            Ok(())
+        };
+        fut.boxed()
     }
 }
 
@@ -445,22 +523,34 @@ mod tests {
 
         let events = stream.take(4).collect::<Vec<_>>().await;
         assert_eq!(events.len(), 4);
-        assert_eq!(events[0].status, Status::Running);
-        assert_eq!(events[1].status, Status::Running);
+        assert!(events.contains(&Event {
+            id: 0,
+            status: Status::Running
+        }));
+        assert!(events.contains(&Event {
+            id: 1,
+            status: Status::Running
+        }));
 
-        assert!(events[2].is_complete());
+        // These may complete out of order, so find the correct events.
+        let complete0 = events
+            .iter()
+            .find(|event| event.is_complete() && event.id == 0)
+            .unwrap();
         assert_registry_contains_values(
             &registry,
             default_storage_name,
-            &events[2].clone().outputs().unwrap(),
+            &complete0.clone().outputs().unwrap_or_default(),
             json!({"value": 4}),
         );
-
-        assert!(events[3].is_complete());
+        let complete1 = events
+            .iter()
+            .find(|event| event.is_complete() && event.id == 1)
+            .unwrap();
         assert_registry_contains_values(
             &registry,
             default_storage_name,
-            &events[3].clone().outputs().unwrap(),
+            &complete1.clone().outputs().unwrap_or_default(),
             json!({"value": 12}),
         );
 
@@ -558,7 +648,7 @@ mod tests {
         let event = stream.next().await.unwrap();
         assert_eq!(event.status, Status::Running);
 
-        executor.cancel(task_ids)?;
+        executor.cancel(task_ids).await?;
 
         let event = stream.next().await.unwrap();
         assert_eq!(event.status, Status::Cancelled);
@@ -573,7 +663,7 @@ mod tests {
         let (registry, _, _) = test_storage_registry(vec![], vec![]);
         let executor = InMemoryExecutor::try_new(&registry, "memory")?;
 
-        executor.cancel(vec![0])?;
+        executor.cancel(vec![0]).await?;
 
         Ok(())
     }
@@ -609,7 +699,7 @@ mod tests {
             json!({"value": 4}),
         );
 
-        executor.cancel(task_ids)?;
+        executor.cancel(task_ids).await?;
 
         Ok(())
     }

--- a/tierkreis/src/executor/interface.rs
+++ b/tierkreis/src/executor/interface.rs
@@ -73,5 +73,5 @@ pub trait Executor: Send + Sync {
     /// # Errors
     ///
     /// Will return Err if the [Executor] is unreachable.
-    fn cancel(&self, task_ids: Vec<u32>) -> miette::Result<()>;
+    fn cancel(&self, task_ids: Vec<u32>) -> BoxFuture<'_, miette::Result<()>>;
 }

--- a/tierkreis/src/executor/subprocess.rs
+++ b/tierkreis/src/executor/subprocess.rs
@@ -10,9 +10,9 @@ use std::{
 };
 
 use futures::{
-    FutureExt, StreamExt,
+    FutureExt, SinkExt, StreamExt,
     channel::mpsc,
-    future::{self, BoxFuture},
+    future::BoxFuture,
     stream::{BoxStream, FuturesUnordered},
 };
 use miette::{Context, IntoDiagnostic, miette};
@@ -75,6 +75,103 @@ type CancelReceiver = mpsc::Receiver<u32>;
 
 type RunningFutures = FuturesUnordered<JoinHandle<BackgroundTask>>;
 
+async fn process_cancelled_task(
+    event_sender: &mut EventSender,
+    abort_handles: &mut HashMap<u32, AbortHandle>,
+    id: u32,
+) -> miette::Result<()> {
+    let handle = abort_handles.remove(&id);
+    if let Some(handle) = handle {
+        handle.abort();
+        send_cancelled(event_sender, id).await?;
+    }
+    Ok(())
+}
+
+async fn process_finished_task(
+    event_sender: &mut EventSender,
+    abort_handles: &mut HashMap<u32, AbortHandle>,
+    asset_storage_registry: &AssetStorageRegistry,
+    background_task: BackgroundTask,
+) -> miette::Result<()> {
+    let id = background_task.id;
+    let outputs = background_task.outputs;
+    let output_storage_name = background_task.output_storage_name;
+    let exit_status = background_task.exit_status;
+
+    abort_handles.remove(&id);
+    match exit_status {
+        Ok(status) => {
+            if status.success() {
+                let outputs =
+                    transfer_assets(asset_storage_registry, &output_storage_name, &outputs);
+                match outputs {
+                    Ok(outputs) => send_complete(event_sender, id, outputs).await?,
+                    Err(err) => send_error(event_sender, id, &err).await?,
+                }
+            } else {
+                let stderr = background_task.stderr.await.ok();
+                event_sender
+                    .send(Event {
+                        id,
+                        status: Status::Error {
+                            error: format!("Subprocess failed with exit code: {status}"),
+                            detail: stderr,
+                        },
+                    })
+                    .await
+                    .map_err(|err| miette!("Failed to send error event: {err}"))?;
+            }
+        }
+        Err(err) => send_error(event_sender, id, &miette!("Failed to run worker: {err}")).await?,
+    }
+
+    Ok(())
+}
+
+async fn start_task(
+    event_sender: &mut EventSender,
+    abort_handles: &mut HashMap<u32, AbortHandle>,
+    running: &mut RunningFutures,
+    internal_task: BackgroundTaskPlan,
+) -> miette::Result<()> {
+    let id = internal_task.id;
+    send_running(event_sender, id).await?;
+
+    let worker_args = internal_task.worker_args;
+    let worker_args_path = worker_args.path();
+    let done_file = internal_task.done_file;
+    let res = spawn_worker(&internal_task.worker_name, worker_args_path);
+    let mut child = match res {
+        Ok(child) => child,
+        Err(err) => {
+            send_error(event_sender, id, &err).await?;
+            return Ok(());
+        }
+    };
+    let stderr = read_stderr(&mut child);
+
+    let outputs = internal_task.outputs;
+    let output_storage_name = internal_task.output_storage_name;
+    let task = tokio::task::spawn(async move {
+        let exit_status = child.wait().await;
+        BackgroundTask {
+            id,
+            output_storage_name,
+            exit_status,
+            outputs,
+            stderr,
+            _worker_args: worker_args,
+            _done_file: done_file,
+        }
+    });
+
+    abort_handles.insert(id, task.abort_handle());
+    running.push(task);
+
+    Ok(())
+}
+
 async fn process_tasks(
     mut task_receiver: TaskReceiver,
     mut cancel_receiver: CancelReceiver,
@@ -88,11 +185,9 @@ async fn process_tasks(
         tokio::select! {
             // A task has been cancelled
             Some(id) = cancel_receiver.next() => {
-                let handle = abort_handles.remove(&id);
-                if let Some(handle) = handle {
-                    handle.abort();
-                    send_cancelled(&mut event_sender, id);
-                }
+                process_cancelled_task(&mut event_sender, &mut abort_handles, id)
+                    .await
+                    .expect("Failed to cancel task");
             }
             // A task has completed
             Some(res) = running.next() => {
@@ -101,73 +196,25 @@ async fn process_tasks(
                     Err(err) => panic!("Failed to join to future: {err}"),
                 };
 
-                let id = background_task.id;
-                let outputs = background_task.outputs;
-                let output_storage_name = background_task.output_storage_name;
-                let exit_status = background_task.exit_status;
-
-                abort_handles.remove(&id);
-                match exit_status {
-                    Ok(status) => {
-                        if status.success() {
-                            let outputs = transfer_assets(
-                                &asset_storage_registry,
-                                &output_storage_name,
-                                outputs,
-                            );
-                            match outputs {
-                                Ok(outputs) => send_complete(&mut event_sender, id, outputs),
-                                Err(err) => send_error(&mut event_sender, id, &err),
-                            }
-                        } else {
-                            let stderr = background_task.stderr.await.ok();
-                            event_sender
-                                .try_send(Event {
-                                    id,
-                                    status: Status::Error {error: format!("Subprocess failed with exit code: {status}"), detail: stderr },
-                                })
-                                .expect("Failed to send Error event.");
-                        }
-                    }
-                    Err(err) => send_error(&mut event_sender, id, &miette!("Failed to run worker: {err}")),
-                }
-
+                process_finished_task(
+                    &mut event_sender,
+                    &mut abort_handles,
+                    &asset_storage_registry,
+                    background_task,
+                )
+                .await
+                .expect("Failed to complete task");
             }
             // A task has been submitted
             Some(internal_task) = task_receiver.next() => {
-                let id = internal_task.id;
-                send_running(&mut event_sender, id);
-
-                let worker_args = internal_task.worker_args;
-                let worker_args_path = worker_args.path();
-                let done_file = internal_task.done_file;
-                let res = spawn_worker(&internal_task.worker_name, worker_args_path);
-                let mut child = match res {
-                    Ok(child) => child,
-                    Err(err) => {
-                        send_error(&mut event_sender, id, &err);
-                        continue;
-                    }
-                };
-                let stderr = read_stderr(&mut child);
-
-                let outputs = internal_task.outputs;
-                let output_storage_name = internal_task.output_storage_name;
-                let task = tokio::task::spawn(async move {
-                    let exit_status = child.wait().await;
-                    BackgroundTask {
-                        id,
-                        output_storage_name,
-                        exit_status,
-                        outputs,
-                        stderr,
-                        _worker_args: worker_args,
-                        _done_file: done_file,
-                    }
-                });
-
-                abort_handles.insert(id, task.abort_handle());
-                running.push(task);
+                start_task(
+                    &mut event_sender,
+                    &mut abort_handles,
+                    &mut running,
+                    internal_task,
+                )
+                .await
+                .expect("Failed to start task");
             }
         }
     }
@@ -270,7 +317,7 @@ impl SubprocessExecutor {
 
     fn build_inputs(
         &self,
-        inputs: HashMap<String, AssetSpec>,
+        inputs: &HashMap<String, AssetSpec>,
     ) -> Result<HashMap<String, PathBuf>, miette::Error> {
         let inputs = transfer_assets(
             &self.asset_storage_registry,
@@ -278,7 +325,7 @@ impl SubprocessExecutor {
             inputs,
         )?;
         let inputs =
-            write_input_paths(inputs).wrap_err("Failed to collect Worker input filepaths")?;
+            write_input_paths(&inputs).wrap_err("Failed to collect Worker input filepaths")?;
         Ok(inputs)
     }
 
@@ -335,7 +382,7 @@ struct WorkerCallArgs {
 
 // Write the paths of the inputs to the worker.
 fn write_input_paths(
-    inputs: HashMap<String, AssetSpec>,
+    inputs: &HashMap<String, AssetSpec>,
 ) -> miette::Result<HashMap<String, PathBuf>> {
     let inputs_len = inputs.len();
     let mut input_paths = HashMap::with_capacity(inputs_len);
@@ -353,7 +400,7 @@ impl Executor for SubprocessExecutor {
     }
 
     fn execute(&self, task_plans: Vec<TaskPlan>) -> BoxFuture<'_, miette::Result<Vec<u32>>> {
-        let res = || {
+        let fut = async {
             let mut ids = Vec::new();
             let mut task_sender = self.task_sender.clone();
 
@@ -361,7 +408,7 @@ impl Executor for SubprocessExecutor {
                 let id = self
                     .id_source
                     .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                let inputs = self.build_inputs(task_plan.inputs)?;
+                let inputs = self.build_inputs(&task_plan.inputs)?;
                 let (outputs, output_paths) = self.build_outputs(task_plan.outputs)?;
 
                 let worker_args = NamedTempFile::new().into_diagnostic()?;
@@ -389,7 +436,7 @@ impl Executor for SubprocessExecutor {
                     .unwrap_or_else(|| self.output_storage_name.clone());
 
                 task_sender
-                    .try_send(BackgroundTaskPlan {
+                    .send(BackgroundTaskPlan {
                         id,
                         worker_name: task_plan.worker_name,
                         output_storage_name,
@@ -397,6 +444,7 @@ impl Executor for SubprocessExecutor {
                         done_file,
                         outputs,
                     })
+                    .await
                     .into_diagnostic()?;
 
                 ids.push(id);
@@ -404,7 +452,7 @@ impl Executor for SubprocessExecutor {
 
             Ok(ids)
         };
-        future::ready(res()).boxed()
+        fut.boxed()
     }
 
     fn listen(&self) -> miette::Result<BoxStream<'_, Event>> {
@@ -423,12 +471,15 @@ impl Executor for SubprocessExecutor {
         Ok(channel.boxed())
     }
 
-    fn cancel(&self, task_ids: Vec<u32>) -> miette::Result<()> {
-        let mut cancel_sender = self.cancel_sender.clone();
-        for task_id in task_ids {
-            cancel_sender.try_send(task_id).into_diagnostic()?;
-        }
-        Ok(())
+    fn cancel(&self, task_ids: Vec<u32>) -> BoxFuture<'_, miette::Result<()>> {
+        let fut = async {
+            let mut cancel_sender = self.cancel_sender.clone();
+            for task_id in task_ids {
+                cancel_sender.send(task_id).await.into_diagnostic()?;
+            }
+            Ok(())
+        };
+        fut.boxed()
     }
 }
 
@@ -732,7 +783,7 @@ mod tests {
         let event = stream.next().await.unwrap();
         assert_eq!(event.status, Status::Running);
 
-        executor.cancel(task_ids)?;
+        executor.cancel(task_ids).await?;
 
         let event = stream.next().await.unwrap();
         assert_eq!(event.status, Status::Cancelled);
@@ -747,7 +798,7 @@ mod tests {
         let (registry, _, _) = test_storage_registry(vec![], vec![]);
         let executor = SubprocessExecutor::try_new(&registry, "file", "file")?;
 
-        executor.cancel(vec![0])?;
+        executor.cancel(vec![0]).await?;
 
         Ok(())
     }
@@ -787,7 +838,7 @@ mod tests {
             json!({"value": "hello dave"}),
         );
 
-        executor.cancel(task_ids)?;
+        executor.cancel(task_ids).await?;
 
         Ok(())
     }

--- a/tierkreis/src/orchestrator.rs
+++ b/tierkreis/src/orchestrator.rs
@@ -133,12 +133,12 @@ impl Orchestrator {
                     outputs = transfer_assets(
                         &self.asset_storage_registry,
                         &self.default_storage_name,
-                        outputs,
+                        &outputs,
                     )?;
                 }
 
                 let mut event_sender = self.event_sender.clone();
-                send_complete(&mut event_sender, 0, outputs);
+                send_complete(&mut event_sender, 0, outputs).await?;
             }
             Node::Output {} => {
                 // Notify that the outputs are ready
@@ -147,36 +147,40 @@ impl Orchestrator {
                 let outputs = transfer_assets(
                     &self.asset_storage_registry,
                     &self.default_storage_name,
-                    inputs,
+                    &inputs,
                 )
                 .wrap_err("Could not run Output Node")?;
-                send_complete(&mut event_sender, 0, outputs);
+                send_complete(&mut event_sender, 0, outputs).await?;
             }
             Node::Const { value } => {
                 // Load the constant value into the correct storage.
-                let asset_storage_registry_lock =
-                    self.asset_storage_registry.read().map_err(|err| {
-                        miette!("Failed to lock AssetStorageRegistry for reading: {err}")
-                    })?;
-                let default_storage_name = &self.default_storage_name;
-                let asset_storage = asset_storage_registry_lock
+                let outputs = {
+                    let asset_storage_registry_lock =
+                        self.asset_storage_registry.read().map_err(|err| {
+                            miette!("Failed to lock AssetStorageRegistry for reading: {err}")
+                        })?;
+                    let default_storage_name = &self.default_storage_name;
+                    let asset_storage = asset_storage_registry_lock
                     .get(default_storage_name)
                     .ok_or_else(|| miette!("Could not find a storage with name '{default_storage_name}' in AssetStorageRegistry"))?;
-                let asset_key = AssetKey::new();
-                asset_storage.save(&asset_key, serde_json::to_vec(&value).into_diagnostic()?)?;
+                    let asset_key = AssetKey::new();
+                    asset_storage
+                        .save(&asset_key, serde_json::to_vec(&value).into_diagnostic()?)?;
 
-                let mut outputs = HashMap::new();
-                outputs.insert(
-                    "value".to_string(),
-                    AssetSpec {
-                        kind: asset_storage.kind(),
-                        storage_name: self.default_storage_name.clone(),
-                        asset_key,
-                    },
-                );
+                    let mut outputs = HashMap::new();
+                    outputs.insert(
+                        "value".to_string(),
+                        AssetSpec {
+                            kind: asset_storage.kind(),
+                            storage_name: self.default_storage_name.clone(),
+                            asset_key,
+                        },
+                    );
+                    outputs
+                };
 
                 let mut event_sender = self.event_sender.clone();
-                send_complete(&mut event_sender, 0, outputs);
+                send_complete(&mut event_sender, 0, outputs).await?;
             }
             Node::Eval {} => {
                 // spawn a sub-orchestrator?


### PR DESCRIPTION
* Consolidate Task types
* Factor out tokio::select bodies into functions
* Use futures::prelude::Sink to send mpsc events using futures.
* Replace panics in send_* functions with errors.