### PR TITLE
feat: Add State storage component

### DIFF
--- a/tierkreis/src/lib.rs
+++ b/tierkreis/src/lib.rs
@@ -12,3 +12,4 @@ pub mod location;
 pub mod orchestrator;
 pub mod runtime;
 pub mod server;
+pub mod state;

--- a/tierkreis/src/state.rs
+++ b/tierkreis/src/state.rs
@@ -1,0 +1,9 @@
+/*!
+This module defines the interface and some standard implementations of [`RuntimeState`]
+and [`WorkflowState`].
+*/
+pub mod inmemory;
+pub mod interface;
+
+pub use inmemory::{InMemoryRuntimeState, InMemoryWorkflowState};
+pub use interface::{RuntimeState, WorkflowState};

--- a/tierkreis/src/state/inmemory.rs
+++ b/tierkreis/src/state/inmemory.rs
@@ -21,6 +21,7 @@ use futures::{
 use miette::miette;
 use uuid::Uuid;
 
+use crate::state::interface::RunAttemptUpdated;
 use crate::{
     event::Event,
     location::Location,
@@ -30,11 +31,15 @@ use crate::{
     },
 };
 
+/// [`RunAttemptState`] is the full state of a run.
 #[derive(Debug, Default)]
 struct RunAttemptState {
     nodes: HashMap<Location, NodeState>,
 }
 
+/// [`InMemoryRuntimeStateInner`] is a shared struct that can be accessed
+/// by both [`InMemoryRuntimeState`] and [`InMemoryWorkflowState`] through shared
+/// references.
 #[derive(Debug, Default)]
 struct InMemoryRuntimeStateInner {
     runs: DashMap<(Uuid, u32), RunAttemptState>,
@@ -45,8 +50,8 @@ struct InMemoryRuntimeStateInner {
 #[derive(Debug)]
 pub struct InMemoryRuntimeState {
     inner: Arc<InMemoryRuntimeStateInner>,
-    update_sender: mpsc::Sender<(Uuid, u32, bool)>,
-    update_receiver: Mutex<Option<mpsc::Receiver<(Uuid, u32, bool)>>>,
+    update_sender: mpsc::Sender<RunAttemptUpdated>,
+    update_receiver: Mutex<Option<mpsc::Receiver<RunAttemptUpdated>>>,
 }
 
 impl InMemoryRuntimeState {
@@ -73,6 +78,10 @@ impl Default for InMemoryRuntimeState {
 
 impl RuntimeState for InMemoryRuntimeState {
     fn workflow_state(&self, run_id: Uuid, attempt: u32) -> Arc<dyn WorkflowState> {
+        let entry = self.inner.runs.entry((run_id, attempt));
+        // Insert the default if the value does not yet exist.
+        entry.or_default();
+
         Arc::new(InMemoryWorkflowState {
             global_state: Arc::clone(&self.inner),
             update_sender: self.update_sender.clone(),
@@ -81,7 +90,7 @@ impl RuntimeState for InMemoryRuntimeState {
         })
     }
 
-    fn listen(&self) -> miette::Result<BoxStream<'static, (Uuid, u32, bool)>> {
+    fn listen(&self) -> miette::Result<BoxStream<'static, RunAttemptUpdated>> {
         let receiver = {
             let mut receiver = self
                 .update_receiver
@@ -102,7 +111,7 @@ impl RuntimeState for InMemoryRuntimeState {
 #[derive(Debug)]
 pub struct InMemoryWorkflowState {
     global_state: Arc<InMemoryRuntimeStateInner>,
-    update_sender: mpsc::Sender<(Uuid, u32, bool)>,
+    update_sender: mpsc::Sender<RunAttemptUpdated>,
     run_id: Uuid,
     attempt: u32,
 }
@@ -116,7 +125,7 @@ impl InMemoryWorkflowState {
     /// Will panic if `listen` returns an error, but this should be impossible.
     #[cfg(test)]
     #[must_use]
-    pub fn test() -> (Self, BoxStream<'static, (Uuid, u32, bool)>) {
+    pub fn test() -> (Self, BoxStream<'static, RunAttemptUpdated>) {
         let global_state = InMemoryRuntimeState::new();
         let events = global_state.listen().unwrap();
         global_state
@@ -198,7 +207,11 @@ impl WorkflowState for InMemoryWorkflowState {
         async move {
             if send_update {
                 update_sender
-                    .send((self.run_id, self.attempt, send_workflow_complete))
+                    .send(RunAttemptUpdated {
+                        run_id: self.run_id,
+                        attempt: self.attempt,
+                        complete: send_workflow_complete,
+                    })
                     .await
                     .map_err(|err| miette!("Send failed: {err}"))?;
             }
@@ -231,5 +244,44 @@ impl WorkflowState for InMemoryWorkflowState {
         };
 
         future::ready(res()).boxed()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::event::Status;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn listen_for_updates() -> miette::Result<()> {
+        let runtime_state = InMemoryRuntimeState::new();
+
+        let stream = runtime_state.listen().expect("Failed to listen");
+
+        let run_id = Uuid::now_v7();
+        let attempt = 0;
+        let workflow_state = runtime_state.workflow_state(run_id, attempt);
+
+        workflow_state
+            .write(Event {
+                loc: Location::root(),
+                status: Status::Scheduled,
+            })
+            .await
+            .expect("Failed to write state");
+
+        let updated = stream.take(1).collect::<Vec<_>>().await;
+        assert_eq!(updated.len(), 1);
+        assert_eq!(
+            updated[0],
+            RunAttemptUpdated {
+                run_id,
+                attempt,
+                complete: false
+            }
+        );
+
+        Ok(())
     }
 }

--- a/tierkreis/src/state/inmemory.rs
+++ b/tierkreis/src/state/inmemory.rs
@@ -249,7 +249,7 @@ impl WorkflowState for InMemoryWorkflowState {
 
     fn add_metadata(&self, metadata: HashMap<String, String>) -> BoxFuture<'_, miette::Result<()>> {
         let entry = self.global_state.runs.entry((self.run_id, self.attempt));
-        entry.or_default().metadata.extend(metadata.into_iter());
+        entry.or_default().metadata.extend(metadata);
         future::ok(()).boxed()
     }
 

--- a/tierkreis/src/state/inmemory.rs
+++ b/tierkreis/src/state/inmemory.rs
@@ -154,7 +154,7 @@ impl WorkflowState for InMemoryWorkflowState {
             .or_default();
 
         let mut send_update = false;
-        let mut send_workflow_complete = false;
+        let mut send_workflow_stopped = false;
         let node_state = run_state.nodes.entry(event.loc).or_default();
 
         match event.status {
@@ -185,13 +185,15 @@ impl WorkflowState for InMemoryWorkflowState {
                     node_state.complete_time = Some(Utc::now());
                     node_state.outputs = Some(outputs);
 
-                    send_workflow_complete = workflow_complete;
+                    send_workflow_stopped = workflow_complete;
                 }
             }
             crate::event::Status::Cancelled => {
                 if node_state.cancelled_time.is_none() {
                     send_update = true;
                     node_state.cancelled_time = Some(Utc::now());
+
+                    send_workflow_stopped = true;
                 }
             }
             crate::event::Status::Error { error, detail } => {
@@ -200,6 +202,8 @@ impl WorkflowState for InMemoryWorkflowState {
                     node_state.error_time = Some(Utc::now());
                     node_state.error = Some(error);
                     node_state.error_detail = detail;
+
+                    send_workflow_stopped = true;
                 }
             }
         }
@@ -211,7 +215,7 @@ impl WorkflowState for InMemoryWorkflowState {
                     .send(RunAttemptUpdated {
                         run_id: self.run_id,
                         attempt: self.attempt,
-                        complete: send_workflow_complete,
+                        stopped: send_workflow_stopped,
                     })
                     .await
                     .map_err(|err| miette!("Send failed: {err}"))?;
@@ -307,7 +311,7 @@ mod tests {
             RunAttemptUpdated {
                 run_id,
                 attempt,
-                complete: false
+                stopped: false
             }
         );
 

--- a/tierkreis/src/state/inmemory.rs
+++ b/tierkreis/src/state/inmemory.rs
@@ -1,0 +1,235 @@
+/*!
+This module defines the [`InMemoryRuntimeState`] struct which implements [`RuntimeState`]
+that can be used by the tierkreis runtime.
+
+These implementations are intended to be used for testing and debugging as their
+state is not persisted beyond the lifetime of the process.
+*/
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex},
+};
+
+use chrono::Utc;
+use dashmap::DashMap;
+use futures::{
+    FutureExt, SinkExt, StreamExt,
+    channel::mpsc,
+    future::{self, BoxFuture},
+    stream::BoxStream,
+};
+use miette::miette;
+use uuid::Uuid;
+
+use crate::{
+    event::Event,
+    location::Location,
+    state::{
+        WorkflowState,
+        interface::{NodeState, RuntimeState},
+    },
+};
+
+#[derive(Debug, Default)]
+struct RunAttemptState {
+    nodes: HashMap<Location, NodeState>,
+}
+
+#[derive(Debug, Default)]
+struct InMemoryRuntimeStateInner {
+    runs: DashMap<(Uuid, u32), RunAttemptState>,
+}
+
+/// [`InMemoryRuntimeState`] implements [`RuntimeState`] but with an in-memory backing
+/// that will not be persisted outside of the tierkreis runtime process.
+#[derive(Debug)]
+pub struct InMemoryRuntimeState {
+    inner: Arc<InMemoryRuntimeStateInner>,
+    update_sender: mpsc::Sender<(Uuid, u32, bool)>,
+    update_receiver: Mutex<Option<mpsc::Receiver<(Uuid, u32, bool)>>>,
+}
+
+impl InMemoryRuntimeState {
+    /// Create a new [`InMemoryRuntimeState`] instance.
+    #[must_use]
+    pub fn new() -> Self {
+        let (sender, receiver) = mpsc::channel(128);
+        Self {
+            inner: Arc::new(InMemoryRuntimeStateInner {
+                runs: DashMap::new(),
+            }),
+
+            update_sender: sender,
+            update_receiver: Mutex::new(Some(receiver)),
+        }
+    }
+}
+
+impl Default for InMemoryRuntimeState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl RuntimeState for InMemoryRuntimeState {
+    fn workflow_state(&self, run_id: Uuid, attempt: u32) -> Arc<dyn WorkflowState> {
+        Arc::new(InMemoryWorkflowState {
+            global_state: Arc::clone(&self.inner),
+            update_sender: self.update_sender.clone(),
+            run_id,
+            attempt,
+        })
+    }
+
+    fn listen(&self) -> miette::Result<BoxStream<'static, (Uuid, u32, bool)>> {
+        let receiver = {
+            let mut receiver = self
+                .update_receiver
+                .try_lock()
+                .map_err(|err| miette!("Failed to listen: {}", err))?;
+
+            receiver.take().ok_or(miette!(
+                "Failed to listen: InMemoryGlobalState is already being listened to."
+            ))?
+        };
+
+        Ok(receiver.boxed())
+    }
+}
+
+/// [`InMemoryWorkflowState`] is an implementation of [`WorkflowState`] that shares storage
+/// with [`InMemoryRuntimeState`].
+#[derive(Debug)]
+pub struct InMemoryWorkflowState {
+    global_state: Arc<InMemoryRuntimeStateInner>,
+    update_sender: mpsc::Sender<(Uuid, u32, bool)>,
+    run_id: Uuid,
+    attempt: u32,
+}
+
+impl InMemoryWorkflowState {
+    /// Create a test instance of [`InMemoryWorkflowState`] along with a stream of events from a
+    /// paired [`InMemoryRuntimeState`].
+    ///
+    /// # Panics
+    ///
+    /// Will panic if `listen` returns an error, but this should be impossible.
+    #[cfg(test)]
+    #[must_use]
+    pub fn test() -> (Self, BoxStream<'static, (Uuid, u32, bool)>) {
+        let global_state = InMemoryRuntimeState::new();
+        let events = global_state.listen().unwrap();
+        global_state
+            .inner
+            .runs
+            .insert((Uuid::nil(), 0), RunAttemptState::default());
+        (
+            Self {
+                global_state: Arc::clone(&global_state.inner),
+                update_sender: global_state.update_sender.clone(),
+                run_id: Uuid::nil(),
+                attempt: 0,
+            },
+            events,
+        )
+    }
+}
+
+impl WorkflowState for InMemoryWorkflowState {
+    fn write(&self, event: Event) -> BoxFuture<'_, miette::Result<()>> {
+        let global_state = &self.global_state;
+        let mut run_state = global_state
+            .runs
+            .entry((self.run_id, self.attempt))
+            .or_default();
+
+        let mut send_update = false;
+        let mut send_workflow_complete = false;
+        let node_state = run_state.nodes.entry(event.loc).or_default();
+
+        match event.status {
+            crate::event::Status::Scheduled => {
+                if node_state.scheduled_time.is_none() {
+                    send_update = true;
+                    node_state.scheduled_time = Some(Utc::now());
+                }
+            }
+            crate::event::Status::Queued => {
+                if node_state.queued_time.is_none() {
+                    send_update = true;
+                    node_state.queued_time = Some(Utc::now());
+                }
+            }
+            crate::event::Status::Running => {
+                if node_state.running_time.is_none() {
+                    send_update = true;
+                    node_state.running_time = Some(Utc::now());
+                }
+            }
+            crate::event::Status::Complete {
+                outputs,
+                workflow_complete,
+            } => {
+                if node_state.complete_time.is_none() {
+                    send_update = true;
+                    node_state.complete_time = Some(Utc::now());
+                    node_state.outputs = Some(outputs);
+
+                    send_workflow_complete = workflow_complete;
+                }
+            }
+            crate::event::Status::Cancelled => {
+                if node_state.cancelled_time.is_none() {
+                    send_update = true;
+                    node_state.cancelled_time = Some(Utc::now());
+                }
+            }
+            crate::event::Status::Error { error, detail } => {
+                if node_state.error_time.is_none() {
+                    send_update = true;
+                    node_state.error_time = Some(Utc::now());
+                    node_state.error = Some(error);
+                    node_state.error_detail = detail;
+                }
+            }
+        }
+
+        let mut update_sender = self.update_sender.clone();
+        async move {
+            if send_update {
+                update_sender
+                    .send((self.run_id, self.attempt, send_workflow_complete))
+                    .await
+                    .map_err(|err| miette!("Send failed: {err}"))?;
+            }
+            Ok(())
+        }
+        .boxed()
+    }
+
+    fn read(&self, location: &Location) -> BoxFuture<'_, miette::Result<NodeState>> {
+        let global_state = &self.global_state;
+        let res = || {
+            let run_state = global_state
+                .runs
+                .get(&(self.run_id, self.attempt))
+                .ok_or_else(|| {
+                    miette!(
+                        "Run Attempt with id {} and attempt {} not found",
+                        self.run_id,
+                        self.attempt
+                    )
+                })?;
+            let state = run_state
+                .value()
+                .nodes
+                .get(location)
+                .cloned()
+                .unwrap_or_default();
+
+            Ok(state.clone())
+        };
+
+        future::ready(res()).boxed()
+    }
+}

--- a/tierkreis/src/state/inmemory.rs
+++ b/tierkreis/src/state/inmemory.rs
@@ -35,6 +35,7 @@ use crate::{
 #[derive(Debug, Default)]
 struct RunAttemptState {
     nodes: HashMap<Location, NodeState>,
+    metadata: HashMap<String, String>,
 }
 
 /// [`InMemoryRuntimeStateInner`] is a shared struct that can be accessed
@@ -245,6 +246,18 @@ impl WorkflowState for InMemoryWorkflowState {
 
         future::ready(res()).boxed()
     }
+
+    fn add_metadata(&self, metadata: HashMap<String, String>) -> BoxFuture<'_, miette::Result<()>> {
+        let entry = self.global_state.runs.entry((self.run_id, self.attempt));
+        entry.or_default().metadata.extend(metadata.into_iter());
+        future::ok(()).boxed()
+    }
+
+    fn read_metadata(&self) -> BoxFuture<'_, miette::Result<HashMap<String, String>>> {
+        let entry = self.global_state.runs.entry((self.run_id, self.attempt));
+        let metadata = entry.or_default().value().metadata.clone();
+        future::ok(metadata).boxed()
+    }
 }
 
 #[cfg(test)]
@@ -253,11 +266,28 @@ mod tests {
 
     use super::*;
 
+    /// Test that reading a location returns the default value.
     #[tokio::test]
-    async fn listen_for_updates() -> miette::Result<()> {
+    async fn read_location_returns_default() -> miette::Result<()> {
         let runtime_state = InMemoryRuntimeState::new();
 
-        let stream = runtime_state.listen().expect("Failed to listen");
+        let run_id = Uuid::now_v7();
+        let attempt = 0;
+        let workflow_state = runtime_state.workflow_state(run_id, attempt);
+
+        let node_state = workflow_state.read(&Location::root()).await?;
+
+        assert_eq!(node_state, NodeState::default());
+
+        Ok(())
+    }
+
+    /// Test that we can write and listen for updates.
+    #[tokio::test]
+    async fn write_and_listen_for_updates() -> miette::Result<()> {
+        let runtime_state = InMemoryRuntimeState::new();
+
+        let stream = runtime_state.listen()?;
 
         let run_id = Uuid::now_v7();
         let attempt = 0;
@@ -268,8 +298,7 @@ mod tests {
                 loc: Location::root(),
                 status: Status::Scheduled,
             })
-            .await
-            .expect("Failed to write state");
+            .await?;
 
         let updated = stream.take(1).collect::<Vec<_>>().await;
         assert_eq!(updated.len(), 1);
@@ -281,6 +310,71 @@ mod tests {
                 complete: false
             }
         );
+
+        Ok(())
+    }
+
+    /// Test that we can read and write workflow run state.
+    #[tokio::test]
+    async fn write_and_read() -> miette::Result<()> {
+        let runtime_state = InMemoryRuntimeState::new();
+
+        let run_id = Uuid::now_v7();
+        let attempt = 0;
+        let workflow_state = runtime_state.workflow_state(run_id, attempt);
+
+        workflow_state
+            .write(Event {
+                loc: Location::root(),
+                status: Status::Scheduled,
+            })
+            .await?;
+
+        let node_state = workflow_state.read(&Location::root()).await?;
+
+        assert!(node_state.scheduled_time.is_some());
+
+        Ok(())
+    }
+
+    /// Test that we can read and write metadata
+    #[tokio::test]
+    async fn write_and_read_metadata() -> miette::Result<()> {
+        let runtime_state = InMemoryRuntimeState::new();
+
+        let run_id = Uuid::now_v7();
+        let attempt = 0;
+        let workflow_state = runtime_state.workflow_state(run_id, attempt);
+
+        let metadata = HashMap::from_iter([("foo".to_string(), "bar".to_string())]);
+        workflow_state.add_metadata(metadata.clone()).await?;
+
+        let read_metadata = workflow_state.read_metadata().await?;
+
+        assert_eq!(metadata, read_metadata);
+
+        Ok(())
+    }
+
+    /// Test that metadata we write gets merged.
+    #[tokio::test]
+    async fn merge_metadata() -> miette::Result<()> {
+        let runtime_state = InMemoryRuntimeState::new();
+
+        let run_id = Uuid::now_v7();
+        let attempt = 0;
+        let workflow_state = runtime_state.workflow_state(run_id, attempt);
+
+        let mut metadata1 = HashMap::from_iter([("foo".to_string(), "bar".to_string())]);
+        workflow_state.add_metadata(metadata1.clone()).await?;
+
+        let metadata2 = HashMap::from_iter([("baz".to_string(), "boo".to_string())]);
+        workflow_state.add_metadata(metadata2.clone()).await?;
+
+        let read_metadata = workflow_state.read_metadata().await?;
+
+        metadata1.extend(metadata2.into_iter());
+        assert_eq!(metadata1, read_metadata);
 
         Ok(())
     }

--- a/tierkreis/src/state/interface.rs
+++ b/tierkreis/src/state/interface.rs
@@ -10,6 +10,18 @@ use uuid::Uuid;
 
 use crate::{asset_storage::AssetSpec, event::Event, location::Location};
 
+/// [`RunAttemptUpdated`] is a struct that is emitted by the [`RuntimeState`] interface
+/// whenever a run attempt changes, in order to drive further workflow orchestration.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct RunAttemptUpdated {
+    /// The unique identifier of the run.
+    pub run_id: Uuid,
+    /// The number of the run attempt, typically sequential.
+    pub attempt: u32,
+    /// Whether the workflow is complete and no further orchestration is required.
+    pub complete: bool,
+}
+
 /// [`NodeState`] is a struct that stores the possible state that a node
 /// in the Workflow graph can be in.
 ///
@@ -44,6 +56,8 @@ pub struct NodeState {
 pub trait RuntimeState: Debug + Send + Sync {
     /// Retrieve a handle to a [`WorkflowState`] depending on the `run_id` and attempt number.
     ///
+    /// If the backing data for the [`WorkflowState`] does not exist, create it.
+    ///
     /// The [`WorkflowState`] comes inside an `Arc` such that it can be shared between threads.
     fn workflow_state(&self, run_id: Uuid, attempt: u32) -> Arc<dyn WorkflowState>;
     /// Listen for updates about *all* of the running workflows.
@@ -51,10 +65,10 @@ pub trait RuntimeState: Debug + Send + Sync {
     /// # Errors
     ///
     /// Will return Err if the method has already been called.
-    fn listen(&self) -> miette::Result<BoxStream<'static, (Uuid, u32, bool)>>;
+    fn listen(&self) -> miette::Result<BoxStream<'static, RunAttemptUpdated>>;
 }
 
-/// [`WorkfowState`] is an interface to the state of an individual Workflow run attempt.
+/// [`WorkflowState`] is an interface to the state of an individual Workflow run attempt.
 pub trait WorkflowState: Debug + Send + Sync {
     /// Update the [`WorkflowState`] from an [`Event`].
     fn write(&self, event: Event) -> BoxFuture<'_, miette::Result<()>>;

--- a/tierkreis/src/state/interface.rs
+++ b/tierkreis/src/state/interface.rs
@@ -1,0 +1,79 @@
+/*!
+This module defines the interface contracts that the various [`RuntimeState`]
+and [`WorkflowState`] implementations must satisfy.
+*/
+use std::{collections::HashMap, fmt::Debug, sync::Arc};
+
+use chrono::{DateTime, Utc};
+use futures::{FutureExt, future::BoxFuture, stream::BoxStream};
+use uuid::Uuid;
+
+use crate::{asset_storage::AssetSpec, event::Event, location::Location};
+
+/// [`NodeState`] is a struct that stores the possible state that a node
+/// in the Workflow graph can be in.
+///
+/// This state is built up by reading [`Event`] messages and can be queried
+/// by the [`WorkflowState`] interface.
+#[derive(Debug, Clone, Default)]
+pub struct NodeState {
+    /// The time at which the node was scheduled by the [`Orchestrator`] if any.
+    pub scheduled_time: Option<DateTime<Utc>>,
+    /// The time at which the node was queued by an [`Executor`] if any.
+    pub queued_time: Option<DateTime<Utc>>,
+    /// The time at which the node started running by an [`Executor`] if any.
+    pub running_time: Option<DateTime<Utc>>,
+    /// The time at which the node was completed by the [`Orchestrator`] or an [`Executor`] if any.
+    pub complete_time: Option<DateTime<Utc>>,
+    /// The time at which the node was cancelled by the [`Executor`] if any.
+    pub cancelled_time: Option<DateTime<Utc>>,
+    /// The time at which the node errored as reported by the [`Orchestrator`] or an [`Executor`] if any.
+    pub error_time: Option<DateTime<Utc>>,
+
+    /// The outputs of the node and their stored locations if any.
+    pub outputs: Option<HashMap<String, AssetSpec>>,
+
+    /// The error message of the node if any.
+    pub error: Option<String>,
+    /// The detail of the error for the node if any.
+    pub error_detail: Option<String>,
+}
+
+/// [`RuntimeState`] is an interface to the state of the overall tierkreis runtime, across
+/// all of the running and completed Workflows.
+pub trait RuntimeState: Debug + Send + Sync {
+    /// Retrieve a handle to a [`WorkflowState`] depending on the `run_id` and attempt number.
+    ///
+    /// The [`WorkflowState`] comes inside an `Arc` such that it can be shared between threads.
+    fn workflow_state(&self, run_id: Uuid, attempt: u32) -> Arc<dyn WorkflowState>;
+    /// Listen for updates about *all* of the running workflows.
+    ///
+    /// # Errors
+    ///
+    /// Will return Err if the method has already been called.
+    fn listen(&self) -> miette::Result<BoxStream<'static, (Uuid, u32, bool)>>;
+}
+
+/// [`WorkfowState`] is an interface to the state of an individual Workflow run attempt.
+pub trait WorkflowState: Debug + Send + Sync {
+    /// Update the [`WorkflowState`] from an [`Event`].
+    fn write(&self, event: Event) -> BoxFuture<'_, miette::Result<()>>;
+    /// Read the state of a Node at the specified [`Location`].
+    fn read(&self, location: &Location) -> BoxFuture<'_, miette::Result<NodeState>>;
+
+    /// Returns `Ok(true)` if the Node at the specified [`Location`] has been
+    /// scheduled by the [`Orchestrator`].
+    fn is_scheduled(&self, location: &Location) -> BoxFuture<'_, miette::Result<bool>> {
+        self.read(location)
+            .map(|res| res.map(|state| state.scheduled_time.is_some()))
+            .boxed()
+    }
+
+    /// Returns `Ok(true)` if the Node at the specified [`Location`] has recorded
+    /// outputs, which suggests that it has completed.
+    fn has_outputs(&self, location: &Location) -> BoxFuture<'_, miette::Result<bool>> {
+        self.read(location)
+            .map(|res| res.map(|state| state.outputs.is_some()))
+            .boxed()
+    }
+}

--- a/tierkreis/src/state/interface.rs
+++ b/tierkreis/src/state/interface.rs
@@ -18,8 +18,8 @@ pub struct RunAttemptUpdated {
     pub run_id: Uuid,
     /// The number of the run attempt, typically sequential.
     pub attempt: u32,
-    /// Whether the workflow is complete and no further orchestration is required.
-    pub complete: bool,
+    /// Whether the workflow is complete/cancelled/errored and no further orchestration is required.
+    pub stopped: bool,
 }
 
 /// [`NodeState`] is a struct that stores the possible state that a node

--- a/tierkreis/src/state/interface.rs
+++ b/tierkreis/src/state/interface.rs
@@ -74,7 +74,7 @@ pub trait WorkflowState: Debug + Send + Sync {
     fn write(&self, event: Event) -> BoxFuture<'_, miette::Result<()>>;
     /// Read the state of a Node at the specified [`Location`].
     ///
-    /// If the `location` has no existing state, a default NodeState will be returned.
+    /// If the `location` has no existing state, a default [`NodeState`] will be returned.
     fn read(&self, location: &Location) -> BoxFuture<'_, miette::Result<NodeState>>;
     /// Add metadata for the Workflow run. The new metadata will be merged with the existing values.
     fn add_metadata(&self, metadata: HashMap<String, String>) -> BoxFuture<'_, miette::Result<()>>;

--- a/tierkreis/src/state/interface.rs
+++ b/tierkreis/src/state/interface.rs
@@ -27,7 +27,7 @@ pub struct RunAttemptUpdated {
 ///
 /// This state is built up by reading [`Event`] messages and can be queried
 /// by the [`WorkflowState`] interface.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, PartialEq)]
 pub struct NodeState {
     /// The time at which the node was scheduled by the [`Orchestrator`] if any.
     pub scheduled_time: Option<DateTime<Utc>>,
@@ -73,7 +73,13 @@ pub trait WorkflowState: Debug + Send + Sync {
     /// Update the [`WorkflowState`] from an [`Event`].
     fn write(&self, event: Event) -> BoxFuture<'_, miette::Result<()>>;
     /// Read the state of a Node at the specified [`Location`].
+    ///
+    /// If the `location` has no existing state, a default NodeState will be returned.
     fn read(&self, location: &Location) -> BoxFuture<'_, miette::Result<NodeState>>;
+    /// Add metadata for the Workflow run. The new metadata will be merged with the existing values.
+    fn add_metadata(&self, metadata: HashMap<String, String>) -> BoxFuture<'_, miette::Result<()>>;
+    /// Read the metadata for the Workflow run.
+    fn read_metadata(&self) -> BoxFuture<'_, miette::Result<HashMap<String, String>>>;
 
     /// Returns `Ok(true)` if the Node at the specified [`Location`] has been
     /// scheduled by the [`Orchestrator`].


### PR DESCRIPTION
Adds a component that provides an abstract interface to the overall state of the workflow process. This will be updated from a stream of events and used by the orchestrator to drive workflow execution.