### PR TITLE
feat: Enable forward refs with toposort 

### DIFF
--- a/tierkreis/tests/idl/namespace1.py
+++ b/tierkreis/tests/idl/namespace1.py
@@ -23,6 +23,8 @@ class IncludedType(NamedTuple):
 class A(NamedTuple):
     name: dict[str, str]
     age: int
+    b: "B"
+    bs: list[list["B"]]
 
 
 class B(NamedTuple):

--- a/tierkreis/tests/idl/namespace1.tsp
+++ b/tierkreis/tests/idl/namespace1.tsp
@@ -14,6 +14,8 @@ model IncludedType {
 model A {
   name: Record<string>;
   age: uint8;
+  b: B;
+  bs: Array<Array<B>>;
 }
 
 model B {

--- a/tierkreis/tests/idl/stubs_output.py
+++ b/tierkreis/tests/idl/stubs_output.py
@@ -1,47 +1,50 @@
 """Code generated from TestNamespace namespace. Please do not edit."""
 
+# ruff: noqa: F821
 from typing import NamedTuple, Protocol
 from tierkreis.controller.data.models import TKR
 from tierkreis.controller.data.types import PType, Struct
 
 
-class A(NamedTuple):
-    age: TKR[int]  # noqa: F821 # fmt: skip
-    name: TKR[dict[str, str]]  # noqa: F821 # fmt: skip
-
-
 class B(Struct, Protocol):
-    age: int  # noqa: F821 # fmt: skip
-    name: dict[str, str]  # noqa: F821 # fmt: skip
+    age: int
+    name: dict[str, str]
 
 
-class C[T: PType](Struct, Protocol):
-    a: list[int]  # noqa: F821 # fmt: skip
-    b: "B"  # noqa: F821 # fmt: skip
-    included: "IncludedType"  # noqa: F821 # fmt: skip
-    ol: "list[ListItem]"  # noqa: F821 # fmt: skip
-    t: "T"  # noqa: F821 # fmt: skip
-
-
-class IncludedType(Struct, Protocol):
-    nested: "NestedType"  # noqa: F821 # fmt: skip
-
-
-class ListItem(Struct, Protocol):
-    i: int  # noqa: F821 # fmt: skip
+class A(NamedTuple):
+    age: TKR[int]
+    b: TKR[B]
+    bs: TKR[list[list[B]]]
+    name: TKR[dict[str, str]]
 
 
 class NestedType(Struct, Protocol):
-    city: str  # noqa: F821 # fmt: skip
+    city: str
+
+
+class IncludedType(Struct, Protocol):
+    nested: NestedType
+
+
+class ListItem(Struct, Protocol):
+    i: int
+
+
+class C[T: PType](Struct, Protocol):
+    a: list[int]
+    b: B
+    included: IncludedType
+    ol: list[ListItem]
+    t: T
 
 
 class foo(NamedTuple):
-    a: TKR[int]  # noqa: F821 # fmt: skip
-    b: TKR[str]  # noqa: F821 # fmt: skip
+    a: TKR[int]
+    b: TKR[str]
 
     @staticmethod
-    def out() -> type[A]:  # noqa: F821 # fmt: skip
-        return A  # noqa: F821 # fmt: skip
+    def out() -> type[A]:
+        return A
 
     @property
     def namespace(self) -> str:
@@ -50,8 +53,8 @@ class foo(NamedTuple):
 
 class bar(NamedTuple):
     @staticmethod
-    def out() -> type[TKR[B]]:  # noqa: F821 # fmt: skip
-        return TKR[B]  # noqa: F821 # fmt: skip
+    def out() -> type[TKR[B]]:
+        return TKR[B]
 
     @property
     def namespace(self) -> str:
@@ -59,11 +62,11 @@ class bar(NamedTuple):
 
 
 class z[T: PType](NamedTuple):
-    c: TKR[C[T]]  # noqa: F821 # fmt: skip
+    c: TKR[C[T]]
 
     @staticmethod
-    def out() -> type[TKR[C[T]]]:  # noqa: F821 # fmt: skip
-        return TKR[C[T]]  # noqa: F821 # fmt: skip
+    def out() -> type[TKR[C[T]]]:
+        return TKR[C[T]]
 
     @property
     def namespace(self) -> str:

--- a/tierkreis/tests/idl/test_idl.py
+++ b/tierkreis/tests/idl/test_idl.py
@@ -55,3 +55,19 @@ def test_namespace(path: Path, expected: Namespace) -> None:
 def test_parser_fail(type_symb: str) -> None:
     with pytest.raises(TierkreisError):
         type_symbol(type_symb)
+
+
+def test_model_order() -> None:
+    namespace = tests.idl.namespace1.expected_namespace
+    sorted_models = [
+        str(model.t.origin.__qualname__)
+        for model in namespace._topologically_sorted_models()
+    ]
+    assert sorted_models == [
+        "B",
+        "A",
+        "NestedType",
+        "IncludedType",
+        "ListItem",
+        "C",
+    ]

--- a/tierkreis/tierkreis/codegen.py
+++ b/tierkreis/tierkreis/codegen.py
@@ -2,6 +2,7 @@
 
 from inspect import isclass
 from types import NoneType
+from typing import ForwardRef
 
 from hugr.package import Package
 from pydantic import BaseModel
@@ -15,11 +16,13 @@ from tierkreis.controller.data.types import (
 from tierkreis.idl.models import GenericType, Method, Model, TypedArg
 
 
-def format_ptype(ptype: type | str, *, has_serialization: bool = False) -> str:
+def format_ptype(
+    ptype: type | str | ForwardRef, *, has_serialization: bool = False
+) -> str:
     """Format a ptype to a string.
 
     :param ptype: The type to format.
-    :type ptype: type | str
+    :type ptype: type | str | ForwardRef
     :param has_serialization: If it was a custom serialized type.
     :type has_serialization: bool, defaults to False.
     :return: The formatted string representation of the type.
@@ -39,6 +42,8 @@ def format_ptype(ptype: type | str, *, has_serialization: bool = False) -> str:
         return "NoneType"
     if has_serialization:
         return f'OpaqueType["{ptype.__module__}.{ptype.__qualname__}"]'
+    if isinstance(ptype, ForwardRef):
+        return ptype.__forward_arg__
     return ptype.__qualname__
 
 
@@ -93,8 +98,7 @@ def format_typed_arg(typed_arg: TypedArg, *, is_portmapping: bool) -> str:
         include_bound=False,
         is_tkr=not is_portmapping,
     )
-    should_quote = typed_arg.t.included_structs() and is_portmapping
-    type_str = f'"{type_str}"' if should_quote else type_str
+
     default_str = " | None = None " if typed_arg.has_default else ""
     return f"{typed_arg.name}: {type_str}{default_str}"
 

--- a/tierkreis/tierkreis/idl/models.py
+++ b/tierkreis/tierkreis/idl/models.py
@@ -3,7 +3,8 @@
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from types import NoneType
-from typing import Annotated, Self, get_args, get_origin
+from typing import Annotated, Self, get_args, get_origin, ForwardRef
+
 
 from tierkreis.controller.data.core import (
     Deserializer,
@@ -210,3 +211,42 @@ class Model:
         if has_ptypes and has_tkrs:
             raise ValueError("Model decls should be all PTypes or all TKRs")
         return has_ptypes
+
+    def model_dependencies(self, known_models: dict[str, "Model"]) -> set["Model"]:
+        """Get a set of models this model depends on.
+
+        For example, if you have
+        model A { x: int, y: B }
+        model B { z: str }
+        Then A depends on B.
+
+        :param known_models: A dictionary of known models by their name.
+        :type known_models: dict[str, Model]
+        :return: A set of models this model depends on.
+        :rtype: set[Model]
+        """
+        generic_params = {arg for arg in self.t.args if isinstance(arg, str)}
+        deps: set[Model] = set()
+        for decl in self.decls:
+            deps.update(_collect_dependencies(decl.t, generic_params, known_models))
+        return deps
+
+
+def _collect_dependencies(
+    t: GenericType, generic_params: set[str], models_by_name: dict[str, Model]
+) -> set[Model]:
+    """Collect the models that t depends on, excluding generic parameters."""
+    origin = t.origin
+    deps = set()
+    if isinstance(origin, ForwardRef):
+        name = origin.__forward_arg__
+    else:
+        name = getattr(origin, "__qualname__", str(origin))
+    if name not in generic_params:
+        dep = models_by_name.get(name)
+        if dep is not None:
+            deps.add(dep)
+    for arg in t.args:
+        if isinstance(arg, GenericType):
+            deps.update(_collect_dependencies(arg, generic_params, models_by_name))
+    return deps

--- a/tierkreis/tierkreis/namespace.py
+++ b/tierkreis/tierkreis/namespace.py
@@ -120,6 +120,26 @@ class Namespace:
 
         return namespace
 
+    def _topologically_sorted_models(self) -> list[Model]:
+        """Return models sorted so every dependency appears before the model that needs it.
+
+        :return: All internal models sorted topologically.
+        :rtype: list[Model]
+        """
+
+        models_by_name = {
+            m.t.origin
+            if isinstance(m.t.origin, str)
+            else getattr(m.t.origin, "__qualname__", str(m.t.origin)): m
+            for m in self.models
+        }
+
+        result: list[Model] = []
+        visited: set[Model] = set()
+        for model in sorted(self.models):
+            result.extend(_visit(model, visited, models_by_name))
+        return result
+
     def stubs(self) -> str:
         """Generate type stubs strings for the namespace.
 
@@ -128,7 +148,9 @@ class Namespace:
         """
         functions = [format_method(self.name, method) for method in self.methods]
         functions_str = "\n\n".join(functions)
-        models_str = "\n\n".join([format_model(model) for model in sorted(self.models)])
+        models_str = "\n\n".join([
+            format_model(model) for model in self._topologically_sorted_models()
+        ])
 
         return f'''"""Code generated from {self.name} namespace. Please do not edit."""
 
@@ -171,3 +193,16 @@ from tierkreis.controller.data.types import PType, Struct, Workflow
             )
         else:
             logger.warning("No ruff binary found. Stubs will contain raw codegen.")
+
+
+def _visit(
+    model: Model, visited: set[Model], models_by_name: dict[str, Model]
+) -> list[Model]:
+    result = []
+    if model in visited:
+        return result
+    visited.add(model)
+    for dep in sorted(model.model_dependencies(models_by_name)):
+        result.extend(_visit(dep, visited, models_by_name))
+    result.append(model)
+    return result


### PR DESCRIPTION
closes: #171 

Circumvents the problem by sorting model dependencies and writing the dependants last.