### PR TITLE
feat: Expand event types and add Updater

### DIFF
--- a/tierkreis/src/event.rs
+++ b/tierkreis/src/event.rs
@@ -10,37 +10,80 @@ use miette::miette;
 
 use crate::{asset_storage::interface::AssetSpec, location::Location};
 
-/// [Event] messages are emitted from [Executor][crate::executor::Executor] instances and the
-/// [Orchestrator][crate::orchestrator::Orchestrator].
-///
-/// [Event] messages correspond to an update in the state of a Node during the Workflow
-/// execution.
+/// [`Event`] messages correspond to an update in the state of a Workflow run.
 #[derive(Clone, Debug, PartialEq)]
-pub struct Event {
-    /// The location of the Node for this Event.
-    pub loc: Location,
-    /// The new status of the Node.
-    pub status: Status,
+pub enum Event {
+    /// An event relating to the overall workflow.
+    WorkflowRun(WorkflowRunEvent),
+    /// An event relating to a specific node with a [`Location`].
+    Node(NodeEvent),
 }
 
 impl Event {
-    /// Returns `true` if the status field of the event is [`Status::Complete`]
+    /// Returns true if the event indicates that the workflow is finished running.
     #[must_use]
-    pub fn is_complete(&self) -> bool {
-        matches!(self.status, Status::Complete { .. })
+    pub fn is_workflow_finished(&self) -> bool {
+        match self {
+            Event::WorkflowRun(run_event) => run_event.is_workflow_finished(),
+            Event::Node(_) => false,
+        }
     }
 
-    /// Returns `true` if the status field of the event is [`Status::Complete`]
-    /// and the `workflow_complete` field is true.
+    /// Returns true if the event indicates that a node has some specific outputs.
     #[must_use]
-    pub fn is_workflow_complete(&self) -> bool {
+    pub fn outputs(self) -> Option<HashMap<String, AssetSpec>> {
+        match self {
+            Event::Node(node_event) => node_event.outputs(),
+            Event::WorkflowRun(_) => None,
+        }
+    }
+}
+
+/// [`WorkflowRunEvent`] messages relate to updates in the progress of the overall workflow
+/// run.
+#[derive(Clone, Debug, PartialEq)]
+pub enum WorkflowRunEvent {
+    /// The workflow run has started.
+    Started {},
+    /// The workflow run has been cancelled.
+    Cancelled {},
+    /// The workflow run has errored during running.
+    Errored {},
+    /// The workflow run has completed successfully.
+    Completed {},
+}
+
+impl WorkflowRunEvent {
+    /// Returns `true` if the workflow has finished running
+    #[must_use]
+    pub fn is_workflow_finished(&self) -> bool {
         matches!(
-            self.status,
-            Status::Complete {
-                workflow_complete: true,
-                ..
-            }
+            self,
+            WorkflowRunEvent::Cancelled {}
+                | WorkflowRunEvent::Errored {}
+                | WorkflowRunEvent::Completed {}
         )
+    }
+}
+
+/// [`NodeEvent`] messages are emitted from [Executor][crate::executor::Executor] instances and the
+/// [Orchestrator][crate::orchestrator::Orchestrator].
+///
+/// [`NodeEvent`] messages correspond to an update in the state of a Node during the Workflow
+/// execution.
+#[derive(Clone, Debug, PartialEq)]
+pub struct NodeEvent {
+    /// The location of the Node for this Event.
+    pub loc: Location,
+    /// The new status of the Node.
+    pub status: NodeStatus,
+}
+
+impl NodeEvent {
+    /// Returns `true` if the status field of the event is [`Status::Complete`]
+    #[must_use]
+    pub fn is_node_complete(&self) -> bool {
+        matches!(self.status, NodeStatus::Complete { .. })
     }
 
     /// Returns the `outputs` field of a [`Status::Complete`] `status` and
@@ -48,27 +91,64 @@ impl Event {
     #[must_use]
     pub fn outputs(self) -> Option<HashMap<String, AssetSpec>> {
         match self.status {
-            Status::Complete { outputs, .. } => Some(outputs),
+            NodeStatus::Complete { outputs, .. } => Some(outputs),
             _ => None,
         }
     }
 }
 
-/// [Status] defines the various states that Nodes can be in.
+/// [`RunningStateUpdate`] contains extra information about how the state of
+/// a Running node should be updated to track the progress of the workflow run.
 #[derive(Clone, Debug, PartialEq)]
-pub enum Status {
+pub enum RunningStateUpdate {
+    /// The node is "switching" and will resolve when the corresponding
+    /// condition branch resolves.
+    ///
+    /// This state is triggered by an `IfElse` node when a value
+    /// appears on a `pred` port and the corresponding branches
+    /// are still resolving.
+    Switching {
+        /// The value that the `pred` port resolved to.
+        cond: bool,
+    },
+    /// The node is "looping" with the specified index.
+    ///
+    /// This state is triggered by a `Loop` node when it is ready to begin
+    /// the next iteration.
+    Looping {
+        /// The index of the next iteration to perform.
+        index: u32,
+    },
+    /// The node is "mapping" over a data structure of a specified size.
+    ///
+    /// This state is triggered by a `Map` node when it begins running.
+    MapStarted {
+        /// The number of elements in the data structure to be mapped.
+        size: u32,
+    },
+    /// An output for a `Map` node is ready at a specific index.
+    MapElemComplete {
+        /// The index in the data structure that has completed.
+        index: u32,
+    },
+}
+
+/// [`NodeStatus`] defines the various states that Nodes can be in.
+#[derive(Clone, Debug, PartialEq)]
+pub enum NodeStatus {
     /// The node is scheduled to be run by the [Orchestrator].
     Scheduled,
     /// The node is queued to run using an [Executor][crate::executor::Executor].
     Queued,
     /// The node is running on an [Executor][crate::executor::Executor].
-    Running,
+    Running {
+        /// An update to the state of the Node to apply.
+        state_update: Option<RunningStateUpdate>,
+    },
     /// The node is finished and has outputs.
     Complete {
         /// The outputs from the node.
         outputs: HashMap<String, AssetSpec>,
-        /// Indicates the entire top level Workflow is done.
-        workflow_complete: bool,
     },
     /// The node has been cancelled.
     Cancelled,
@@ -100,10 +180,10 @@ pub type EventReceiver = mpsc::Receiver<Event>;
 /// Will return Err if the channel for `event_sender` is full or closed.
 pub async fn send_running(event_sender: &mut EventSender, loc: Location) -> miette::Result<()> {
     event_sender
-        .send(Event {
+        .send(Event::Node(NodeEvent {
             loc,
-            status: Status::Running {},
-        })
+            status: NodeStatus::Running { state_update: None },
+        }))
         .await
         .map_err(|err| miette!("Failed to send running event: {err}"))
 }
@@ -115,10 +195,10 @@ pub async fn send_running(event_sender: &mut EventSender, loc: Location) -> miet
 /// Will return Err if the channel for `event_sender` is full or closed.
 pub async fn send_cancelled(event_sender: &mut EventSender, loc: Location) -> miette::Result<()> {
     event_sender
-        .send(Event {
+        .send(Event::Node(NodeEvent {
             loc,
-            status: Status::Cancelled {},
-        })
+            status: NodeStatus::Cancelled {},
+        }))
         .await
         .map_err(|err| miette!("Failed to send cancelled event: {err}"))
 }
@@ -133,18 +213,114 @@ pub async fn send_complete(
     loc: Location,
     outputs: HashMap<String, AssetSpec, RandomState>,
 ) -> miette::Result<()> {
-    let workflow_complete = loc.is_root();
     event_sender
-        .send(Event {
+        .send(Event::Node(NodeEvent {
             loc: loc.clone(),
-            status: Status::Complete {
-                outputs,
-                workflow_complete,
-            },
-        })
+            status: NodeStatus::Complete { outputs },
+        }))
         .await
         .map_err(|err| {
             miette!("Failed to send complete event: {err}")
+                .wrap_err(miette!("At location: {loc:?}"))
+        })
+}
+
+/// Utility function to send a new [`Event`] with [`Status::Running`] and a conditional value
+/// for how the switch should resolve.
+///
+/// # Errors
+///
+/// Will return Err if the channel for `event_sender` is full or closed.
+pub async fn send_running_switching(
+    event_sender: &mut EventSender,
+    loc: Location,
+    cond: bool,
+) -> miette::Result<()> {
+    event_sender
+        .send(Event::Node(NodeEvent {
+            loc: loc.clone(),
+            status: NodeStatus::Running {
+                state_update: Some(RunningStateUpdate::Switching { cond }),
+            },
+        }))
+        .await
+        .map_err(|err| {
+            miette!("Failed to send switching event: {err}")
+                .wrap_err(miette!("At location: {loc:?}"))
+        })
+}
+
+/// Utility function to send a new [`Event`] with [`Status::Running`] and a loop index value
+/// for the current iteration index of the loop
+///
+/// # Errors
+///
+/// Will return Err if the channel for `event_sender` is full or closed.
+pub async fn send_running_loop(
+    event_sender: &mut EventSender,
+    loc: Location,
+    index: u32,
+) -> miette::Result<()> {
+    event_sender
+        .send(Event::Node(NodeEvent {
+            loc: loc.clone(),
+            status: NodeStatus::Running {
+                state_update: Some(RunningStateUpdate::Looping { index }),
+            },
+        }))
+        .await
+        .map_err(|err| {
+            miette!("Failed to send running loop event: {err}")
+                .wrap_err(miette!("At location: {loc:?}"))
+        })
+}
+
+/// Utility function to send a new [`Event`] with [`Status::Running`] and the number of
+/// elements of the data structure the Map node is being applied to.
+///
+/// # Errors
+///
+/// Will return Err if the channel for `event_sender` is full or closed.
+pub async fn send_running_map(
+    event_sender: &mut EventSender,
+    loc: Location,
+    size: u32,
+) -> miette::Result<()> {
+    event_sender
+        .send(Event::Node(NodeEvent {
+            loc: loc.clone(),
+            status: NodeStatus::Running {
+                state_update: Some(RunningStateUpdate::MapStarted { size }),
+            },
+        }))
+        .await
+        .map_err(|err| {
+            miette!("Failed to send running map event: {err}")
+                .wrap_err(miette!("At location: {loc:?}"))
+        })
+}
+
+/// Utility function to send a new [`Event`] with [`Status::Running`] and index of
+/// the data structure the Map node is being applied to that has finished.
+///
+/// # Errors
+///
+/// Will return Err if the channel for `event_sender` is full or closed.
+pub async fn send_map_elem_complete(
+    event_sender: &mut EventSender,
+    loc: Location,
+    index: u32,
+) -> miette::Result<()> {
+    event_sender
+        .send(Event::Node(NodeEvent {
+            loc: loc.clone(),
+            status: NodeStatus::Running {
+                state_update: Some(RunningStateUpdate::MapElemComplete { index }),
+            },
+        }))
+        .await
+        .map_err(|err| {
+            miette!("Failed to send running map event: {err}")
                 .wrap_err(miette!("At location: {loc:?}"))
         })
 }
@@ -160,13 +336,25 @@ pub async fn send_error(
     err: &miette::Error,
 ) -> miette::Result<()> {
     event_sender
-        .send(Event {
+        .send(Event::Node(NodeEvent {
             loc,
-            status: Status::Error {
+            status: NodeStatus::Error {
                 error: err.to_string(),
                 detail: None,
             },
-        })
+        }))
         .await
         .map_err(|err| miette!("Failed to send error event: {err}"))
+}
+
+/// Utility function to send a new [`Event`].
+///
+/// # Errors
+///
+/// Will return Err if the channel for `event_sender` is full or closed.
+pub async fn send_workflow_run_complete(event_sender: &mut EventSender) -> miette::Result<()> {
+    event_sender
+        .send(Event::WorkflowRun(WorkflowRunEvent::Completed {}))
+        .await
+        .map_err(|err| miette!("Failed to send workflow run complete event: {err}"))
 }

--- a/tierkreis/src/executor/inmemory.rs
+++ b/tierkreis/src/executor/inmemory.rs
@@ -16,12 +16,16 @@ use futures::{
     stream::{BoxStream, FuturesUnordered},
 };
 use miette::{IntoDiagnostic, miette};
+use num_complex::Complex64;
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use tokio::task::{AbortHandle, JoinHandle};
 
 use crate::{
     asset_storage::{AssetStorageRegistry, load_assets, save_assets},
-    event::{Event, send_cancelled, send_complete, send_error, send_running},
+    event::{
+        Event, EventReceiver, EventSender, send_cancelled, send_complete, send_error, send_running,
+    },
     executor::interface::{Executor, TaskPlan, WorkerSpec},
     location::Location,
 };
@@ -42,6 +46,7 @@ struct BackgroundTaskPlan {
     output_storage_name: String,
 }
 
+#[derive(Debug)]
 struct BackgroundTask {
     loc: Location,
     output_storage_name: String,
@@ -50,46 +55,25 @@ struct BackgroundTask {
 
 type TaskSender = mpsc::Sender<BackgroundTaskPlan>;
 type TaskReceiver = mpsc::Receiver<BackgroundTaskPlan>;
-type EventSender = mpsc::Sender<Event>;
-type EventReceiver = mpsc::Receiver<Event>;
 type CancelSender = mpsc::Sender<Location>;
 type CancelReceiver = mpsc::Receiver<Location>;
 
-fn extract_i64(inputs: &HashMap<String, Vec<u8>>, name: &str) -> miette::Result<i64> {
-    let asset = inputs.get(name).ok_or(miette!("Missing input: {name}"))?;
+fn extract_value<'a, T>(inputs: &'a HashMap<String, Vec<u8>>, name: &str) -> miette::Result<T>
+where
+    T: Deserialize<'a>,
+{
+    let asset = inputs
+        .get(name)
+        .ok_or_else(|| miette!("Missing input: {name}"))?;
     let val = serde_json::from_slice(asset).into_diagnostic()?;
 
-    if let Value::Number(val) = val {
-        if let Some(val) = val.as_i64() {
-            Ok(val)
-        } else {
-            Err(miette!("Range error: {val} is not representable as i64"))
-        }
-    } else {
-        Err(miette!("Type error: {val} is not a Number"))
-    }
-}
-
-fn extract_f64(inputs: &HashMap<String, Vec<u8>>, name: &str) -> miette::Result<f64> {
-    let asset = inputs.get(name).ok_or(miette!("Missing input: {name}"))?;
-    let val = serde_json::from_slice(asset).into_diagnostic()?;
-
-    if let Value::Number(val) = val {
-        if let Some(val) = val.as_f64() {
-            Ok(val)
-        } else {
-            Err(miette!("Range error: {val} is not representable as f64"))
-        }
-    } else {
-        Err(miette!("Type error: {val} is not a Number"))
-    }
+    Ok(val)
 }
 
 fn output_value(
     outputs: &mut HashMap<String, Vec<u8>>,
-    value: impl Into<Value>,
+    value: impl Serialize,
 ) -> miette::Result<()> {
-    let value: Value = value.into();
     outputs.insert(
         "value".to_string(),
         serde_json::to_vec(&value).into_diagnostic()?,
@@ -104,30 +88,90 @@ fn run_builtin(
     let mut outputs = HashMap::new();
     match task_name {
         "iadd" => {
-            let a = extract_i64(inputs, "a")?;
-            let b = extract_i64(inputs, "b")?;
+            let a: i64 = extract_value(inputs, "a")?;
+            let b: i64 = extract_value(inputs, "b")?;
 
             output_value(&mut outputs, a + b)?;
         }
         "isub" => {
-            let a = extract_i64(inputs, "a")?;
-            let b = extract_i64(inputs, "b")?;
+            let a: i64 = extract_value(inputs, "a")?;
+            let b: i64 = extract_value(inputs, "b")?;
 
             output_value(&mut outputs, a - b)?;
         }
         "itimes" => {
-            let a = extract_i64(inputs, "a")?;
-            let b = extract_i64(inputs, "b")?;
+            let a: i64 = extract_value(inputs, "a")?;
+            let b: i64 = extract_value(inputs, "b")?;
 
             output_value(&mut outputs, a * b)?;
         }
+        "idivide" => {
+            let a: i64 = extract_value(inputs, "a")?;
+            let b: i64 = extract_value(inputs, "b")?;
+
+            output_value(&mut outputs, a / b)?;
+        }
+        "igt" => {
+            let a: i64 = extract_value(inputs, "a")?;
+            let b: i64 = extract_value(inputs, "b")?;
+
+            output_value(&mut outputs, a > b)?;
+        }
+        "mod" => {
+            let a: i64 = extract_value(inputs, "a")?;
+            let b: i64 = extract_value(inputs, "b")?;
+
+            output_value(&mut outputs, a % b)?;
+        }
+        "eq" => {
+            let a: Value = extract_value(inputs, "a")?;
+            let b: Value = extract_value(inputs, "b")?;
+
+            output_value(&mut outputs, a == b)?;
+        }
+        "neq" => {
+            let a: Value = extract_value(inputs, "a")?;
+            let b: Value = extract_value(inputs, "b")?;
+
+            output_value(&mut outputs, a != b)?;
+        }
+        // Legacy built-in name.
+        "str" | "tkr_str" => {
+            let value: Value = extract_value(inputs, "value")?;
+
+            output_value(&mut outputs, value.to_string())?;
+        }
+        // Legacy built-in name.
+        "tuple" | "tkr_tuple" => {
+            let a: Value = extract_value(inputs, "a")?;
+            let b: Value = extract_value(inputs, "b")?;
+
+            output_value(&mut outputs, [a, b])?;
+        }
+        "untuple" => {
+            let value: (Value, Value) = extract_value(inputs, "value")?;
+
+            outputs.insert(
+                "a".to_string(),
+                serde_json::to_vec(&value.0).into_diagnostic()?,
+            );
+            outputs.insert(
+                "b".to_string(),
+                serde_json::to_vec(&value.1).into_diagnostic()?,
+            );
+        }
+        "conjugate" => {
+            let z: Complex64 = extract_value(inputs, "z")?;
+
+            output_value(&mut outputs, z.conj())?;
+        }
         "sleep" => {
-            let delay_seconds = extract_f64(inputs, "delay_seconds")?;
+            let delay_seconds: f64 = extract_value(inputs, "delay_seconds")?;
             sleep(Duration::from_secs_f64(delay_seconds));
 
             output_value(&mut outputs, true)?;
         }
-        _ => return Err(miette!("Unknown task")),
+        task => return Err(miette!("Unknown task: `{task}`")),
     }
     Ok(outputs)
 }
@@ -165,6 +209,7 @@ async fn process_finished_task(
             return Ok(());
         }
     };
+
     let outputs = save_assets(asset_storage_registry, &output_storage_name, outputs);
     match outputs {
         Ok(outputs) => send_complete(event_sender, loc, outputs).await?,
@@ -299,12 +344,12 @@ impl InMemoryExecutor {
         let (task_sender, task_receiver) = mpsc::channel(64);
         let (event_sender, event_receiver) = mpsc::channel(64);
         let (cancel_sender, cancel_receiver) = mpsc::channel(64);
-        tokio::spawn(process_tasks(
+        tokio::spawn(Box::pin(process_tasks(
             task_receiver,
             cancel_receiver,
             event_sender,
             asset_storage_registry,
-        ));
+        )));
 
         Ok(Self {
             task_sender,
@@ -356,9 +401,9 @@ impl Executor for InMemoryExecutor {
                 .try_lock()
                 .map_err(|err| miette!("Failed to listen: {}", err))?;
 
-            receiver.take().ok_or(miette!(
-                "Failed to listen: Executor is already being listened to."
-            ))?
+            receiver.take().ok_or_else(|| {
+                miette!("Failed to listen: Executor is already being listened to.")
+            })?
         };
         Ok(channel.boxed())
     }
@@ -383,7 +428,7 @@ mod tests {
 
     use crate::{
         asset_storage::{assert_registry_contains_values, test_storage_registry},
-        event::Status,
+        event::{NodeEvent, NodeStatus},
         executor::interface::TaskPlan,
     };
 
@@ -432,7 +477,20 @@ mod tests {
         let events = stream.take(2).collect::<Vec<_>>().await;
         dbg!(&events);
         assert_eq!(events.len(), 2);
-        assert_eq!(events[0].status, Status::Running);
+        assert!(matches!(
+            events[0],
+            Event::Node(NodeEvent {
+                status: NodeStatus::Running { .. },
+                ..
+            })
+        ));
+        assert!(matches!(
+            events[1],
+            Event::Node(NodeEvent {
+                status: NodeStatus::Complete { .. },
+                ..
+            })
+        ));
         assert_registry_contains_values(
             &registry,
             default_storage_name,
@@ -471,7 +529,20 @@ mod tests {
 
         let events = stream.take(2).collect::<Vec<_>>().await;
         assert_eq!(events.len(), 2);
-        assert_eq!(events[0].status, Status::Running);
+        assert!(matches!(
+            events[0],
+            Event::Node(NodeEvent {
+                status: NodeStatus::Running { .. },
+                ..
+            })
+        ));
+        assert!(matches!(
+            events[1],
+            Event::Node(NodeEvent {
+                status: NodeStatus::Complete { .. },
+                ..
+            })
+        ));
         assert_registry_contains_values(
             &registry,
             default_storage_name,
@@ -523,19 +594,27 @@ mod tests {
 
         let events = stream.take(4).collect::<Vec<_>>().await;
         assert_eq!(events.len(), 4);
-        assert!(events.contains(&Event {
+        assert!(events.contains(&Event::Node(NodeEvent {
             loc: loc1.clone(),
-            status: Status::Running
-        }));
-        assert!(events.contains(&Event {
+            status: NodeStatus::Running { state_update: None },
+        })));
+        assert!(events.contains(&Event::Node(NodeEvent {
             loc: loc2.clone(),
-            status: Status::Running
-        }));
+            status: NodeStatus::Running { state_update: None },
+        })));
 
         // These may complete out of order, so find the correct events.
         let complete0 = events
             .iter()
-            .find(|event| event.is_complete() && event.loc == loc1)
+            .find(|event| {
+                matches!(
+                    event,
+                    Event::Node(NodeEvent {
+                        loc,
+                        status: NodeStatus::Complete { .. }
+                    }) if loc == &loc1
+                )
+            })
             .unwrap();
         assert_registry_contains_values(
             &registry,
@@ -545,7 +624,15 @@ mod tests {
         );
         let complete1 = events
             .iter()
-            .find(|event| event.is_complete() && event.loc == loc2)
+            .find(|event| {
+                matches!(
+                    event,
+                    Event::Node(NodeEvent {
+                        loc,
+                        status: NodeStatus::Complete { .. }
+                    }) if loc == &loc2
+                )
+            })
             .unwrap();
         assert_registry_contains_values(
             &registry,
@@ -580,8 +667,20 @@ mod tests {
 
         let events = stream.take(2).collect::<Vec<_>>().await;
         assert_eq!(events.len(), 2);
-        assert_eq!(events[0].status, Status::Running);
-        assert!(events[1].is_complete());
+        assert!(matches!(
+            events[0],
+            Event::Node(NodeEvent {
+                status: NodeStatus::Running { .. },
+                ..
+            })
+        ));
+        assert!(matches!(
+            events[1],
+            Event::Node(NodeEvent {
+                status: NodeStatus::Complete { .. },
+                ..
+            })
+        ));
         assert_registry_contains_values(
             &registry,
             "memory",
@@ -613,14 +712,24 @@ mod tests {
 
         let events = stream.take(2).collect::<Vec<_>>().await;
         assert_eq!(events.len(), 2);
-        assert_eq!(events[0].status, Status::Running);
-        assert_eq!(
-            events[1].status,
-            Status::Error {
-                error: "Unknown task".to_string(),
-                detail: None,
-            }
-        );
+        assert!(matches!(
+            events[0],
+            Event::Node(NodeEvent {
+                status: NodeStatus::Running { .. },
+                ..
+            })
+        ));
+        dbg!(&events[1]);
+        assert!(matches!(
+            &events[1],
+            Event::Node(NodeEvent {
+                status: NodeStatus::Error {
+                    error,
+                    ..
+                },
+                ..
+            }) if error == "Unknown task: `backflip`"
+        ));
 
         Ok(())
     }
@@ -648,12 +757,24 @@ mod tests {
         executor.execute(task_plans).await?;
 
         let event = stream.next().await.unwrap();
-        assert_eq!(event.status, Status::Running);
+        assert!(matches!(
+            event,
+            Event::Node(NodeEvent {
+                status: NodeStatus::Running { .. },
+                ..
+            })
+        ));
 
         executor.cancel(vec![loc]).await?;
 
         let event = stream.next().await.unwrap();
-        assert_eq!(event.status, Status::Cancelled);
+        assert!(matches!(
+            event,
+            Event::Node(NodeEvent {
+                status: NodeStatus::Cancelled,
+                ..
+            })
+        ));
 
         Ok(())
     }
@@ -695,8 +816,20 @@ mod tests {
 
         let events = stream.take(2).collect::<Vec<_>>().await;
         assert_eq!(events.len(), 2);
-        assert_eq!(events[0].status, Status::Running);
-        assert!(events[1].is_complete());
+        assert!(matches!(
+            events[0],
+            Event::Node(NodeEvent {
+                status: NodeStatus::Running { .. },
+                ..
+            })
+        ));
+        assert!(matches!(
+            events[1],
+            Event::Node(NodeEvent {
+                status: NodeStatus::Complete { .. },
+                ..
+            })
+        ));
         assert_registry_contains_values(
             &registry,
             "memory",

--- a/tierkreis/src/executor/subprocess.rs
+++ b/tierkreis/src/executor/subprocess.rs
@@ -30,7 +30,10 @@ use crate::{
     asset_storage::{
         AssetKind, AssetSpec, AssetStorageRegistry, reserve_asset_specs, transfer_assets,
     },
-    event::{Event, Status, send_cancelled, send_complete, send_error, send_running},
+    event::{
+        Event, EventReceiver, EventSender, NodeEvent, NodeStatus, send_cancelled, send_complete,
+        send_error, send_running,
+    },
     executor::interface::{Executor, TaskPlan, WorkerSpec},
     location::Location,
 };
@@ -69,8 +72,6 @@ struct BackgroundTask {
 
 type TaskSender = mpsc::Sender<BackgroundTaskPlan>;
 type TaskReceiver = mpsc::Receiver<BackgroundTaskPlan>;
-type EventSender = mpsc::Sender<Event>;
-type EventReceiver = mpsc::Receiver<Event>;
 type CancelSender = mpsc::Sender<Location>;
 type CancelReceiver = mpsc::Receiver<Location>;
 
@@ -113,13 +114,13 @@ async fn process_finished_task(
             } else {
                 let stderr = background_task.stderr.await.ok();
                 event_sender
-                    .send(Event {
+                    .send(Event::Node(NodeEvent {
                         loc,
-                        status: Status::Error {
+                        status: NodeStatus::Error {
                             error: format!("Subprocess failed with exit code: {status}"),
                             detail: stderr,
                         },
-                    })
+                    }))
                     .await
                     .map_err(|err| miette!("Failed to send error event: {err}"))?;
             }
@@ -302,10 +303,10 @@ impl SubprocessExecutor {
         let task = tokio::task::spawn_blocking(|| {
             let re = Regex::new(r"tkr-.*-worker")
                 .into_diagnostic()
-                .wrap_err("Failed to compile Worker name regex")?;
+                .wrap_err_with(|| "Failed to compile Worker name regex")?;
             let paths = which_re(&re)
                 .into_diagnostic()
-                .wrap_err("Failed to search for Worker binaries")?;
+                .wrap_err_with(|| "Failed to search for Worker binaries")?;
             Ok(paths
                 .map(|path| WorkerSpec {
                     worker_name: path.file_name().unwrap().to_str().unwrap().to_string(),
@@ -324,8 +325,8 @@ impl SubprocessExecutor {
             &self.subprocess_storage_name,
             inputs,
         )?;
-        let inputs =
-            write_input_paths(&inputs).wrap_err("Failed to collect Worker input filepaths")?;
+        let inputs = write_input_paths(&inputs)
+            .wrap_err_with(|| "Failed to collect Worker input filepaths")?;
         Ok(inputs)
     }
 
@@ -354,7 +355,7 @@ fn spawn_worker(
         .stderr(Stdio::piped())
         .spawn()
         .into_diagnostic()
-        .wrap_err(miette!("Could not spawn worker"))?;
+        .wrap_err_with(|| miette!("Could not spawn worker"))?;
     Ok(child)
 }
 
@@ -458,9 +459,9 @@ impl Executor for SubprocessExecutor {
                 .try_lock()
                 .map_err(|err| miette!("Failed to listen: {}", err))?;
 
-            receiver.take().ok_or(miette!(
-                "Failed to listen: Executor is already being listened to."
-            ))?
+            receiver.take().ok_or_else(|| {
+                miette!("Failed to listen: Executor is already being listened to.")
+            })?
         };
         Ok(channel.boxed())
     }
@@ -544,7 +545,20 @@ mod tests {
 
         let events = stream.take(2).collect::<Vec<_>>().await;
         assert_eq!(events.len(), 2);
-        assert_eq!(events[0].status, Status::Running);
+        assert!(matches!(
+            events[0],
+            Event::Node(NodeEvent {
+                status: NodeStatus::Running { .. },
+                ..
+            })
+        ));
+        assert!(matches!(
+            events[1],
+            Event::Node(NodeEvent {
+                status: NodeStatus::Complete { .. },
+                ..
+            })
+        ));
         assert_registry_contains_values(
             &registry,
             output_storage_name,
@@ -588,7 +602,20 @@ mod tests {
 
         let events = stream.take(2).collect::<Vec<_>>().await;
         assert_eq!(events.len(), 2);
-        assert_eq!(events[0].status, Status::Running);
+        assert!(matches!(
+            events[0],
+            Event::Node(NodeEvent {
+                status: NodeStatus::Running { .. },
+                ..
+            })
+        ));
+        assert!(matches!(
+            events[1],
+            Event::Node(NodeEvent {
+                status: NodeStatus::Complete { .. },
+                ..
+            })
+        ));
         assert_registry_contains_values(
             &registry,
             output_storage_name,
@@ -647,19 +674,27 @@ mod tests {
 
         let events = stream.take(4).collect::<Vec<_>>().await;
         assert_eq!(events.len(), 4);
-        assert!(events.contains(&Event {
+        assert!(events.contains(&Event::Node(NodeEvent {
             loc: loc1.clone(),
-            status: Status::Running
-        }));
-        assert!(events.contains(&Event {
+            status: NodeStatus::Running { state_update: None },
+        })));
+        assert!(events.contains(&Event::Node(NodeEvent {
             loc: loc2.clone(),
-            status: Status::Running
-        }));
+            status: NodeStatus::Running { state_update: None },
+        })));
 
         // These may complete out of order, so find the correct events.
         let complete0 = events
             .iter()
-            .find(|event| event.is_complete() && event.loc == loc1)
+            .find(|event| {
+                matches!(
+                    event,
+                    Event::Node(NodeEvent {
+                        loc,
+                        status: NodeStatus::Complete { .. }
+                    }) if loc == &loc1
+                )
+            })
             .unwrap();
         assert_registry_contains_values(
             &registry,
@@ -669,7 +704,15 @@ mod tests {
         );
         let complete1 = events
             .iter()
-            .find(|event| event.is_complete() && event.loc == loc2)
+            .find(|event| {
+                matches!(
+                    event,
+                    Event::Node(NodeEvent {
+                        loc,
+                        status: NodeStatus::Complete { .. }
+                    }) if loc == &loc2
+                )
+            })
             .unwrap();
         assert_registry_contains_values(
             &registry,
@@ -709,7 +752,20 @@ mod tests {
 
         let events = stream.take(2).collect::<Vec<_>>().await;
         assert_eq!(events.len(), 2);
-        assert_eq!(events[0].status, Status::Running);
+        assert!(matches!(
+            events[0],
+            Event::Node(NodeEvent {
+                status: NodeStatus::Running { .. },
+                ..
+            })
+        ));
+        assert!(matches!(
+            events[1],
+            Event::Node(NodeEvent {
+                status: NodeStatus::Complete { .. },
+                ..
+            })
+        ));
         assert_registry_contains_values(
             &registry,
             "file",
@@ -741,14 +797,23 @@ mod tests {
 
         let events = stream.take(2).collect::<Vec<_>>().await;
         assert_eq!(events.len(), 2);
-        assert_eq!(events[0].status, Status::Running);
-        matches!(
-            &events[1].status,
-            Status::Error {
-                error,
+        assert!(matches!(
+            events[0],
+            Event::Node(NodeEvent {
+                status: NodeStatus::Running { .. },
                 ..
-            } if error == "Subprocess failed with exit code: exit status: 1",
-        );
+            })
+        ));
+        assert!(matches!(
+            &events[1],
+            Event::Node(NodeEvent {
+                status: NodeStatus::Error {
+                    error,
+                    ..
+                },
+                ..
+            }) if error == "Subprocess failed with exit code: exit status: 1"
+        ));
 
         Ok(())
     }
@@ -781,12 +846,24 @@ mod tests {
         executor.execute(task_plans).await?;
 
         let event = stream.next().await.unwrap();
-        assert_eq!(event.status, Status::Running);
+        assert!(matches!(
+            event,
+            Event::Node(NodeEvent {
+                status: NodeStatus::Running { .. },
+                ..
+            })
+        ));
 
         executor.cancel(vec![loc]).await?;
 
         let event = stream.next().await.unwrap();
-        assert_eq!(event.status, Status::Cancelled);
+        assert!(matches!(
+            event,
+            Event::Node(NodeEvent {
+                status: NodeStatus::Cancelled,
+                ..
+            })
+        ));
 
         Ok(())
     }
@@ -833,7 +910,20 @@ mod tests {
 
         let events = stream.take(2).collect::<Vec<_>>().await;
         assert_eq!(events.len(), 2);
-        assert_eq!(events[0].status, Status::Running);
+        assert!(matches!(
+            events[0],
+            Event::Node(NodeEvent {
+                status: NodeStatus::Running { .. },
+                ..
+            })
+        ));
+        assert!(matches!(
+            events[1],
+            Event::Node(NodeEvent {
+                status: NodeStatus::Complete { .. },
+                ..
+            })
+        ));
         assert_registry_contains_values(
             &registry,
             "file",

--- a/tierkreis/src/lib.rs
+++ b/tierkreis/src/lib.rs
@@ -13,3 +13,4 @@ pub mod orchestrator;
 pub mod runtime;
 pub mod server;
 pub mod state;
+pub mod updater;

--- a/tierkreis/src/orchestrator.rs
+++ b/tierkreis/src/orchestrator.rs
@@ -382,7 +382,7 @@ mod tests {
 
     use crate::{
         asset_storage::{assert_registry_contains_values, test_storage_registry},
-        event::Status,
+        event::{NodeEvent, NodeStatus},
         executor::{
             inmemory::InMemoryExecutor, interface::Executor, subprocess::SubprocessExecutor,
         },
@@ -431,7 +431,13 @@ mod tests {
 
         let events = stream.take(2).collect::<Vec<_>>().await;
         assert_eq!(events.len(), 2);
-        assert_eq!(events[0].status, Status::Running);
+        assert_eq!(
+            events[0],
+            Event::Node(NodeEvent {
+                loc: Location::new("")?,
+                status: NodeStatus::Running { state_update: None }
+            })
+        );
         assert_registry_contains_values(
             &registry,
             &orchestrator.default_storage_name,
@@ -617,7 +623,13 @@ mod tests {
         orchestrator.perform_actions([(node, inputs)]).await?;
 
         let task_running_event = stream.next().await.unwrap();
-        assert_eq!(task_running_event.status, Status::Running);
+        assert_eq!(
+            task_running_event,
+            Event::Node(NodeEvent {
+                loc: Location::new("")?,
+                status: NodeStatus::Running { state_update: None }
+            })
+        );
         let task_complete_event = stream.next().await.unwrap();
         let mut task_complete_outputs = task_complete_event.outputs().unwrap();
         assert_registry_contains_values(

--- a/tierkreis/src/state/inmemory.rs
+++ b/tierkreis/src/state/inmemory.rs
@@ -20,7 +20,7 @@ use futures::{
     stream::BoxStream,
 };
 use miette::miette;
-use tracing::{info, instrument};
+use tracing::instrument;
 use uuid::Uuid;
 
 use crate::{
@@ -288,7 +288,6 @@ fn handle_node_event(
         crate::event::NodeStatus::Running {
             state_update: Some(RunningStateUpdate::MapElemComplete { index }),
         } => {
-            info!("map_completed: {index}");
             if let Some(map_completed) = node_state.map_completed.as_mut() {
                 map_completed.set(index as usize, true);
                 *send_update = true;

--- a/tierkreis/src/state/inmemory.rs
+++ b/tierkreis/src/state/inmemory.rs
@@ -10,6 +10,7 @@ use std::{
     sync::{Arc, Mutex},
 };
 
+use bitvec::vec::BitVec;
 use chrono::Utc;
 use dashmap::DashMap;
 use futures::{
@@ -19,11 +20,15 @@ use futures::{
     stream::BoxStream,
 };
 use miette::miette;
+use tracing::{info, instrument};
 use uuid::Uuid;
 
-use crate::state::interface::RunAttemptUpdated;
 use crate::{
-    event::Event,
+    event::{Event, WorkflowRunEvent},
+    state::interface::RunAttemptUpdated,
+};
+use crate::{
+    event::{NodeEvent, RunningStateUpdate},
     location::Location,
     state::{
         WorkflowState,
@@ -59,7 +64,8 @@ impl InMemoryRuntimeState {
     /// Create a new [`InMemoryRuntimeState`] instance.
     #[must_use]
     pub fn new() -> Self {
-        let (sender, receiver) = mpsc::channel(128);
+        // TODO: This channel clogs up easily if left un-checked.
+        let (sender, receiver) = mpsc::channel(1024);
         Self {
             inner: Arc::new(InMemoryRuntimeStateInner {
                 runs: DashMap::new(),
@@ -98,9 +104,9 @@ impl RuntimeState for InMemoryRuntimeState {
                 .try_lock()
                 .map_err(|err| miette!("Failed to listen: {}", err))?;
 
-            receiver.take().ok_or(miette!(
-                "Failed to listen: InMemoryGlobalState is already being listened to."
-            ))?
+            receiver.take().ok_or_else(|| {
+                miette!("Failed to listen: InMemoryGlobalState is already being listened to.")
+            })?
         };
 
         Ok(receiver.boxed())
@@ -146,71 +152,27 @@ impl InMemoryWorkflowState {
 }
 
 impl WorkflowState for InMemoryWorkflowState {
+    #[instrument]
     fn write(&self, event: Event) -> BoxFuture<'_, miette::Result<()>> {
         let global_state = &self.global_state;
-        let mut run_state = global_state
+        let run_state = global_state
             .runs
             .entry((self.run_id, self.attempt))
             .or_default();
 
         let mut send_update = false;
         let mut send_workflow_stopped = false;
-        let node_state = run_state.nodes.entry(event.loc).or_default();
 
-        match event.status {
-            crate::event::Status::Scheduled => {
-                if node_state.scheduled_time.is_none() {
-                    send_update = true;
-                    node_state.scheduled_time = Some(Utc::now());
-                }
+        match event {
+            Event::WorkflowRun(run_event) => {
+                handle_run_event(&mut send_workflow_stopped, &run_event);
             }
-            crate::event::Status::Queued => {
-                if node_state.queued_time.is_none() {
-                    send_update = true;
-                    node_state.queued_time = Some(Utc::now());
-                }
-            }
-            crate::event::Status::Running => {
-                if node_state.running_time.is_none() {
-                    send_update = true;
-                    node_state.running_time = Some(Utc::now());
-                }
-            }
-            crate::event::Status::Complete {
-                outputs,
-                workflow_complete,
-            } => {
-                if node_state.complete_time.is_none() {
-                    send_update = true;
-                    node_state.complete_time = Some(Utc::now());
-                    node_state.outputs = Some(outputs);
-
-                    send_workflow_stopped = workflow_complete;
-                }
-            }
-            crate::event::Status::Cancelled => {
-                if node_state.cancelled_time.is_none() {
-                    send_update = true;
-                    node_state.cancelled_time = Some(Utc::now());
-
-                    send_workflow_stopped = true;
-                }
-            }
-            crate::event::Status::Error { error, detail } => {
-                if node_state.error_time.is_none() {
-                    send_update = true;
-                    node_state.error_time = Some(Utc::now());
-                    node_state.error = Some(error);
-                    node_state.error_detail = detail;
-
-                    send_workflow_stopped = true;
-                }
-            }
+            Event::Node(node_event) => handle_node_event(run_state, &mut send_update, node_event),
         }
 
         let mut update_sender = self.update_sender.clone();
         async move {
-            if send_update {
+            if send_update || send_workflow_stopped {
                 update_sender
                     .send(RunAttemptUpdated {
                         run_id: self.run_id,
@@ -225,6 +187,7 @@ impl WorkflowState for InMemoryWorkflowState {
         .boxed()
     }
 
+    #[instrument]
     fn read(&self, location: &Location) -> BoxFuture<'_, miette::Result<NodeState>> {
         let global_state = &self.global_state;
         let res = || {
@@ -264,9 +227,100 @@ impl WorkflowState for InMemoryWorkflowState {
     }
 }
 
+fn handle_run_event(send_workflow_stopped: &mut bool, run_event: &WorkflowRunEvent) {
+    match run_event {
+        WorkflowRunEvent::Started {} => {}
+        WorkflowRunEvent::Cancelled {}
+        | WorkflowRunEvent::Errored {}
+        | WorkflowRunEvent::Completed {} => *send_workflow_stopped = true,
+    }
+}
+
+fn handle_node_event(
+    mut run_state: dashmap::mapref::one::RefMut<'_, (Uuid, u32), RunAttemptState>,
+    send_update: &mut bool,
+    node_event: NodeEvent,
+) {
+    let node_state = run_state.nodes.entry(node_event.loc).or_default();
+    match node_event.status {
+        crate::event::NodeStatus::Scheduled => {
+            if node_state.scheduled_time.is_none() {
+                *send_update = true;
+                node_state.scheduled_time = Some(Utc::now());
+            }
+        }
+        crate::event::NodeStatus::Queued => {
+            if node_state.queued_time.is_none() {
+                *send_update = true;
+                node_state.queued_time = Some(Utc::now());
+            }
+        }
+        crate::event::NodeStatus::Running { state_update: None } => {
+            if node_state.running_time.is_none() {
+                *send_update = true;
+                node_state.running_time = Some(Utc::now());
+            }
+        }
+        crate::event::NodeStatus::Running {
+            state_update: Some(RunningStateUpdate::Switching { cond }),
+        } => {
+            if node_state.cond.is_none() {
+                *send_update = true;
+                node_state.cond = Some(cond);
+            }
+        }
+        crate::event::NodeStatus::Running {
+            state_update: Some(RunningStateUpdate::Looping { index }),
+        } => {
+            if node_state.loop_index != Some(index) {
+                *send_update = true;
+                node_state.loop_index = Some(index);
+            }
+        }
+        crate::event::NodeStatus::Running {
+            state_update: Some(RunningStateUpdate::MapStarted { size }),
+        } => {
+            if node_state.map_completed.is_none() {
+                *send_update = true;
+                node_state.map_completed = Some(BitVec::repeat(false, size as usize));
+            }
+        }
+        crate::event::NodeStatus::Running {
+            state_update: Some(RunningStateUpdate::MapElemComplete { index }),
+        } => {
+            info!("map_completed: {index}");
+            if let Some(map_completed) = node_state.map_completed.as_mut() {
+                map_completed.set(index as usize, true);
+                *send_update = true;
+            }
+        }
+        crate::event::NodeStatus::Complete { outputs } => {
+            if node_state.complete_time.is_none() {
+                *send_update = true;
+                node_state.complete_time = Some(Utc::now());
+                node_state.outputs = Some(outputs);
+            }
+        }
+        crate::event::NodeStatus::Cancelled => {
+            if node_state.cancelled_time.is_none() {
+                *send_update = true;
+                node_state.cancelled_time = Some(Utc::now());
+            }
+        }
+        crate::event::NodeStatus::Error { error, detail } => {
+            if node_state.error_time.is_none() {
+                *send_update = true;
+                node_state.error_time = Some(Utc::now());
+                node_state.error = Some(error);
+                node_state.error_detail = detail;
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use crate::event::Status;
+    use crate::event::NodeStatus;
 
     use super::*;
 
@@ -298,10 +352,10 @@ mod tests {
         let workflow_state = runtime_state.workflow_state(run_id, attempt);
 
         workflow_state
-            .write(Event {
+            .write(Event::Node(NodeEvent {
                 loc: Location::root(),
-                status: Status::Scheduled,
-            })
+                status: NodeStatus::Scheduled,
+            }))
             .await?;
 
         let updated = stream.take(1).collect::<Vec<_>>().await;
@@ -328,10 +382,10 @@ mod tests {
         let workflow_state = runtime_state.workflow_state(run_id, attempt);
 
         workflow_state
-            .write(Event {
+            .write(Event::Node(NodeEvent {
                 loc: Location::root(),
-                status: Status::Scheduled,
-            })
+                status: NodeStatus::Scheduled,
+            }))
             .await?;
 
         let node_state = workflow_state.read(&Location::root()).await?;

--- a/tierkreis/src/state/interface.rs
+++ b/tierkreis/src/state/interface.rs
@@ -4,8 +4,9 @@ and [`WorkflowState`] implementations must satisfy.
 */
 use std::{collections::HashMap, fmt::Debug, sync::Arc};
 
+use bitvec::vec::BitVec;
 use chrono::{DateTime, Utc};
-use futures::{FutureExt, future::BoxFuture, stream::BoxStream};
+use futures::{future::BoxFuture, stream::BoxStream};
 use uuid::Uuid;
 
 use crate::{asset_storage::AssetSpec, event::Event, location::Location};
@@ -45,6 +46,15 @@ pub struct NodeState {
     /// The outputs of the node and their stored locations if any.
     pub outputs: Option<HashMap<String, AssetSpec>>,
 
+    /// The state associated with the `pred` port if this Node is an `IfElse` node.
+    pub cond: Option<bool>,
+    /// The state associated with the loop index if this Node is a `Loop` node.
+    pub loop_index: Option<u32>,
+    /// The state associated with a map if this Node is a `Map` node.
+    ///
+    /// This value tracks the number of elements being mapped over.
+    pub map_completed: Option<BitVec>,
+
     /// The error message of the node if any.
     pub error: Option<String>,
     /// The detail of the error for the node if any.
@@ -80,20 +90,4 @@ pub trait WorkflowState: Debug + Send + Sync {
     fn add_metadata(&self, metadata: HashMap<String, String>) -> BoxFuture<'_, miette::Result<()>>;
     /// Read the metadata for the Workflow run.
     fn read_metadata(&self) -> BoxFuture<'_, miette::Result<HashMap<String, String>>>;
-
-    /// Returns `Ok(true)` if the Node at the specified [`Location`] has been
-    /// scheduled by the [`Orchestrator`].
-    fn is_scheduled(&self, location: &Location) -> BoxFuture<'_, miette::Result<bool>> {
-        self.read(location)
-            .map(|res| res.map(|state| state.scheduled_time.is_some()))
-            .boxed()
-    }
-
-    /// Returns `Ok(true)` if the Node at the specified [`Location`] has recorded
-    /// outputs, which suggests that it has completed.
-    fn has_outputs(&self, location: &Location) -> BoxFuture<'_, miette::Result<bool>> {
-        self.read(location)
-            .map(|res| res.map(|state| state.outputs.is_some()))
-            .boxed()
-    }
 }

--- a/tierkreis/src/state/sql.rs
+++ b/tierkreis/src/state/sql.rs
@@ -122,7 +122,8 @@ impl SqliteRuntimeState {
     /// Panics if the `SQLite` database connection pool cannot be established.
     #[must_use]
     pub fn new() -> Self {
-        let (sender, receiver) = mpsc::channel(128);
+        // TODO: This channel clogs up easily if left un-checked.
+        let (sender, receiver) = mpsc::channel(1024);
         let connection = establish_connection().expect("Failed to establish database connection");
         Self {
             connection: Arc::new(connection),

--- a/tierkreis/src/state/sql.rs
+++ b/tierkreis/src/state/sql.rs
@@ -24,20 +24,24 @@ use futures::{
 use miette::miette;
 use uuid::Uuid;
 
-use crate::state::{
-    interface::RunAttemptUpdated,
-    queries::{
-        add_run_metadata, insert_default_node_state, insert_default_workflowrun, read_node_state,
-        read_run_metadata, read_workflowrun, set_cancelled_if_none, set_complete_if_none,
-        set_error_if_none, set_queued_if_none, set_running_if_none, set_scheduled_if_none,
-    },
-};
 use crate::{
-    event::Event,
+    event::{Event, NodeStatus},
     location::Location,
     state::{
         WorkflowState,
         interface::{NodeState, RuntimeState},
+    },
+};
+use crate::{
+    event::{NodeEvent, WorkflowRunEvent},
+    state::{
+        interface::RunAttemptUpdated,
+        queries::{
+            add_run_metadata, insert_default_node_state, insert_default_workflowrun,
+            read_node_state, read_run_metadata, read_workflowrun, set_cancelled_if_none,
+            set_complete_if_none, set_error_if_none, set_queued_if_none, set_running_if_none,
+            set_scheduled_if_none,
+        },
     },
 };
 
@@ -182,52 +186,20 @@ impl SqliteWorkflowState {}
 
 impl WorkflowState for SqliteWorkflowState {
     fn write(&self, event: Event) -> BoxFuture<'_, miette::Result<()>> {
+        let mut send_update = false;
         let mut send_workflow_stopped = false;
-        let loc = event.loc.clone();
-        if let Err(err) =
-            insert_default_node_state(&loc, self.run_id, self.attempt, &self.global_state)
-        {
-            return future::ready(Err(err)).boxed();
+
+        let res = match event {
+            Event::WorkflowRun(run_event) => {
+                let _: () = Self::handle_run_event(&mut send_workflow_stopped, &run_event);
+                Ok(())
+            }
+            Event::Node(node_event) => self.handle_node_event(node_event, &mut send_update),
+        };
+
+        if res.is_err() {
+            return future::ready(res).boxed();
         }
-
-        let send_update_result = match event.status {
-            crate::event::Status::Scheduled => {
-                set_scheduled_if_none(&loc, self.run_id, self.attempt, &self.global_state)
-            }
-            crate::event::Status::Queued => {
-                set_queued_if_none(&loc, self.run_id, self.attempt, &self.global_state)
-            }
-            crate::event::Status::Running => {
-                set_running_if_none(&loc, self.run_id, self.attempt, &self.global_state)
-            }
-            crate::event::Status::Complete {
-                outputs: _,
-                workflow_complete,
-            } => {
-                send_workflow_stopped = workflow_complete;
-                set_complete_if_none(&loc, self.run_id, self.attempt, &self.global_state)
-            }
-            crate::event::Status::Cancelled => {
-                send_workflow_stopped = true;
-                set_cancelled_if_none(&loc, self.run_id, self.attempt, &self.global_state)
-            }
-            crate::event::Status::Error { error, detail } => {
-                send_workflow_stopped = true;
-                set_error_if_none(
-                    &loc,
-                    self.run_id,
-                    self.attempt,
-                    error,
-                    detail,
-                    &self.global_state,
-                )
-            }
-        };
-
-        let send_update = match send_update_result {
-            Ok(changed) => changed,
-            Err(err) => return future::ready(Err(err)).boxed(),
-        };
 
         let mut update_sender = self.update_sender.clone();
         async move {
@@ -272,10 +244,53 @@ impl WorkflowState for SqliteWorkflowState {
     }
 }
 
+impl SqliteWorkflowState {
+    fn handle_run_event(send_workflow_stopped: &mut bool, run_event: &WorkflowRunEvent) {
+        match run_event {
+            WorkflowRunEvent::Started {} => {}
+            WorkflowRunEvent::Cancelled {}
+            | WorkflowRunEvent::Errored {}
+            | WorkflowRunEvent::Completed {} => *send_workflow_stopped = true,
+        }
+    }
+
+    fn handle_node_event(&self, event: NodeEvent, send_update: &mut bool) -> miette::Result<()> {
+        let loc = event.loc.clone();
+        insert_default_node_state(&loc, self.run_id, self.attempt, &self.global_state)?;
+
+        *send_update = match event.status {
+            NodeStatus::Scheduled => {
+                set_scheduled_if_none(&loc, self.run_id, self.attempt, &self.global_state)
+            }
+            NodeStatus::Queued => {
+                set_queued_if_none(&loc, self.run_id, self.attempt, &self.global_state)
+            }
+            NodeStatus::Running { .. } => {
+                set_running_if_none(&loc, self.run_id, self.attempt, &self.global_state)
+            }
+            NodeStatus::Complete { outputs: _ } => {
+                set_complete_if_none(&loc, self.run_id, self.attempt, &self.global_state)
+            }
+            NodeStatus::Cancelled => {
+                set_cancelled_if_none(&loc, self.run_id, self.attempt, &self.global_state)
+            }
+            NodeStatus::Error { error, detail } => set_error_if_none(
+                &loc,
+                self.run_id,
+                self.attempt,
+                error,
+                detail,
+                &self.global_state,
+            ),
+        }?;
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
 
-    use crate::event::Status;
+    use crate::event::NodeStatus;
 
     use super::*;
 
@@ -307,10 +322,10 @@ mod tests {
         let workflow_state = runtime_state.workflow_state(run_id, attempt);
 
         workflow_state
-            .write(Event {
+            .write(Event::Node(NodeEvent {
                 loc: Location::root(),
-                status: Status::Scheduled,
-            })
+                status: NodeStatus::Scheduled,
+            }))
             .await?;
 
         let updated = stream.take(1).collect::<Vec<_>>().await;
@@ -337,10 +352,10 @@ mod tests {
         let workflow_state = runtime_state.workflow_state(run_id, attempt);
 
         workflow_state
-            .write(Event {
+            .write(Event::Node(NodeEvent {
                 loc: Location::root(),
-                status: Status::Scheduled,
-            })
+                status: NodeStatus::Scheduled,
+            }))
             .await?;
 
         let node_state = workflow_state.read(&Location::root()).await?;

--- a/tierkreis/src/updater.rs
+++ b/tierkreis/src/updater.rs
@@ -5,7 +5,6 @@ of [Event] and write each event to a [`WorkflowState`].
 use std::sync::Arc;
 
 use futures::{Stream, StreamExt};
-use tracing::info;
 
 use crate::{event::Event, state::WorkflowState};
 
@@ -32,7 +31,6 @@ impl Updater {
         mut stream: impl Stream<Item = Event> + Unpin,
     ) -> miette::Result<()> {
         while let Some(event) = stream.next().await {
-            info!("got event {event:?}");
             let workflow_finished = event.is_workflow_finished();
             self.state.write(event).await?;
             if workflow_finished {

--- a/tierkreis/src/updater.rs
+++ b/tierkreis/src/updater.rs
@@ -1,0 +1,78 @@
+/*!
+This module defines the [Updater] struct which provides a way to consume a stream
+of [Event] and write each event to a [`WorkflowState`].
+*/
+use std::sync::Arc;
+
+use futures::{Stream, StreamExt};
+use tracing::info;
+
+use crate::{event::Event, state::WorkflowState};
+
+/// [Updater] encapsulates a [`WorkflowState`] and allows the processing of [Event]s.
+pub struct Updater {
+    state: Arc<dyn WorkflowState>,
+}
+
+impl Updater {
+    /// Construct a new [Updater].
+    pub fn new(state: Arc<dyn WorkflowState>) -> Self {
+        Self { state }
+    }
+
+    /// Process a stream of events until an event declaring the
+    /// workflow is complete.
+    ///
+    /// # Errors
+    ///
+    /// Will return Err if the updater fails to write the [Event] to
+    /// the contained [`WorkflowState`].
+    pub async fn process(
+        self,
+        mut stream: impl Stream<Item = Event> + Unpin,
+    ) -> miette::Result<()> {
+        while let Some(event) = stream.next().await {
+            info!("got event {event:?}");
+            let workflow_finished = event.is_workflow_finished();
+            self.state.write(event).await?;
+            if workflow_finished {
+                return Ok(());
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use futures::stream::once;
+    use rstest::rstest;
+
+    use crate::{
+        event::{NodeEvent, NodeStatus},
+        location::Location,
+        state::inmemory::InMemoryWorkflowState,
+    };
+
+    use super::*;
+
+    #[rstest]
+    #[tokio::test]
+    async fn consume_single_event() -> miette::Result<()> {
+        let (state, _events) = InMemoryWorkflowState::test();
+        let updater = Updater::new(Arc::new(state));
+
+        let stream = once(async {
+            Event::Node(NodeEvent {
+                loc: Location::from_usize_iter([0]),
+                status: NodeStatus::Running { state_update: None },
+            })
+        })
+        .boxed();
+
+        updater.process(stream).await?;
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
The updater listens to a stream of events from the `Orchestrator` and uses them to save changes to a `State` implementation.