### PR TITLE
feat: Multiple locations in events

### DIFF
--- a/tierkreis/src/event.rs
+++ b/tierkreis/src/event.rs
@@ -30,7 +30,7 @@ impl Event {
         }
     }
 
-    /// Returns true if the event indicates that a node has some specific outputs.
+    /// Returns the outputs from locations specified in the event if any.
     #[must_use]
     pub fn outputs(self) -> Vec<HashMap<String, AssetSpec>> {
         match self {
@@ -87,8 +87,7 @@ impl NodeEvent {
         matches!(self.status, NodeStatus::Complete { .. })
     }
 
-    /// Returns the `outputs` field of a [`Status::Complete`] `status` and
-    /// None if the `status` field is any other variant.
+    /// Returns the outputs from locations specified in the event if any.
     #[must_use]
     pub fn outputs(self) -> Vec<HashMap<String, AssetSpec>> {
         match self.status {

--- a/tierkreis/src/event.rs
+++ b/tierkreis/src/event.rs
@@ -5,6 +5,7 @@ state of the Workflow so it can be monitored and restarted.
 */
 use std::{collections::HashMap, hash::RandomState};
 
+use bitvec::vec::BitVec;
 use futures::{SinkExt, channel::mpsc};
 use miette::{IntoDiagnostic, miette};
 
@@ -31,10 +32,10 @@ impl Event {
 
     /// Returns true if the event indicates that a node has some specific outputs.
     #[must_use]
-    pub fn outputs(self) -> Option<HashMap<String, AssetSpec>> {
+    pub fn outputs(self) -> Vec<HashMap<String, AssetSpec>> {
         match self {
             Event::Node(node_event) => node_event.outputs(),
-            Event::WorkflowRun(_) => None,
+            Event::WorkflowRun(_) => Vec::new(),
         }
     }
 }
@@ -74,7 +75,7 @@ impl WorkflowRunEvent {
 #[derive(Clone, Debug, PartialEq)]
 pub struct NodeEvent {
     /// The location of the Node for this Event.
-    pub loc: Location,
+    pub locs: Vec<Location>,
     /// The new status of the Node.
     pub status: NodeStatus,
 }
@@ -89,10 +90,10 @@ impl NodeEvent {
     /// Returns the `outputs` field of a [`Status::Complete`] `status` and
     /// None if the `status` field is any other variant.
     #[must_use]
-    pub fn outputs(self) -> Option<HashMap<String, AssetSpec>> {
+    pub fn outputs(self) -> Vec<HashMap<String, AssetSpec>> {
         match self.status {
-            NodeStatus::Complete { outputs, .. } => Some(outputs),
-            _ => None,
+            NodeStatus::Complete { outputs, .. } => outputs,
+            _ => Vec::new(),
         }
     }
 }
@@ -129,7 +130,7 @@ pub enum RunningStateUpdate {
     /// An output for a `Map` node is ready at a specific index.
     MapElemComplete {
         /// The index in the data structure that has completed.
-        index: u32,
+        bits: BitVec,
     },
 }
 
@@ -147,8 +148,8 @@ pub enum NodeStatus {
     },
     /// The node is finished and has outputs.
     Complete {
-        /// The outputs from the node.
-        outputs: HashMap<String, AssetSpec>,
+        /// The outputs from the nodes
+        outputs: Vec<HashMap<String, AssetSpec>>,
     },
     /// The node has been cancelled.
     Cancelled,
@@ -181,7 +182,7 @@ pub type EventReceiver = mpsc::Receiver<Event>;
 pub async fn send_running(event_sender: &mut EventSender, loc: Location) -> miette::Result<()> {
     event_sender
         .send(Event::Node(NodeEvent {
-            loc,
+            locs: vec![loc],
             status: NodeStatus::Running { state_update: None },
         }))
         .await
@@ -196,7 +197,7 @@ pub async fn send_running(event_sender: &mut EventSender, loc: Location) -> miet
 pub async fn send_cancelled(event_sender: &mut EventSender, loc: Location) -> miette::Result<()> {
     event_sender
         .send(Event::Node(NodeEvent {
-            loc,
+            locs: vec![loc],
             status: NodeStatus::Cancelled {},
         }))
         .await
@@ -210,19 +211,16 @@ pub async fn send_cancelled(event_sender: &mut EventSender, loc: Location) -> mi
 /// Will return Err if the channel for `event_sender` is full or closed.
 pub async fn send_complete(
     event_sender: &mut EventSender,
-    loc: Location,
-    outputs: HashMap<String, AssetSpec, RandomState>,
+    locs: Vec<Location>,
+    outputs: Vec<HashMap<String, AssetSpec, RandomState>>,
 ) -> miette::Result<()> {
     event_sender
         .send(Event::Node(NodeEvent {
-            loc: loc.clone(),
+            locs,
             status: NodeStatus::Complete { outputs },
         }))
         .await
-        .map_err(|err| {
-            miette!("Failed to send complete event: {err}")
-                .wrap_err(miette!("At location: {loc:?}"))
-        })
+        .map_err(|err| miette!("Failed to send complete event: {err}"))
 }
 
 /// Utility function to send a new [`Event`] with [`Status::Running`] and a conditional value
@@ -238,7 +236,7 @@ pub async fn send_running_switching(
 ) -> miette::Result<()> {
     event_sender
         .send(Event::Node(NodeEvent {
-            loc: loc.clone(),
+            locs: vec![loc.clone()],
             status: NodeStatus::Running {
                 state_update: Some(RunningStateUpdate::Switching { cond }),
             },
@@ -263,7 +261,7 @@ pub async fn send_running_loop(
 ) -> miette::Result<()> {
     event_sender
         .send(Event::Node(NodeEvent {
-            loc: loc.clone(),
+            locs: vec![loc.clone()],
             status: NodeStatus::Running {
                 state_update: Some(RunningStateUpdate::Looping { index }),
             },
@@ -289,7 +287,7 @@ pub async fn send_running_map(
 ) -> miette::Result<()> {
     event_sender
         .send(Event::Node(NodeEvent {
-            loc: loc.clone(),
+            locs: vec![loc.clone()],
             status: NodeStatus::Running {
                 state_update: Some(RunningStateUpdate::MapStarted {
                     size: u32::try_from(size).into_diagnostic()?,
@@ -313,15 +311,13 @@ pub async fn send_running_map(
 pub async fn send_map_elem_complete(
     event_sender: &mut EventSender,
     loc: Location,
-    index: usize,
+    bits: BitVec,
 ) -> miette::Result<()> {
     event_sender
         .send(Event::Node(NodeEvent {
-            loc: loc.clone(),
+            locs: vec![loc.clone()],
             status: NodeStatus::Running {
-                state_update: Some(RunningStateUpdate::MapElemComplete {
-                    index: u32::try_from(index).into_diagnostic()?,
-                }),
+                state_update: Some(RunningStateUpdate::MapElemComplete { bits }),
             },
         }))
         .await
@@ -343,7 +339,7 @@ pub async fn send_error(
 ) -> miette::Result<()> {
     event_sender
         .send(Event::Node(NodeEvent {
-            loc,
+            locs: vec![loc],
             status: NodeStatus::Error {
                 error: err.to_string(),
                 detail: None,

--- a/tierkreis/src/executor/inmemory.rs
+++ b/tierkreis/src/executor/inmemory.rs
@@ -248,7 +248,7 @@ async fn process_finished_task(
 
     let outputs = save_assets(asset_storage_registry, &output_storage_name, outputs);
     match outputs {
-        Ok(outputs) => send_complete(event_sender, loc, outputs).await?,
+        Ok(outputs) => send_complete(event_sender, vec![loc], vec![outputs]).await?,
         Err(err) => send_error(event_sender, loc, &err).await?,
     }
 
@@ -530,7 +530,7 @@ mod tests {
         assert_registry_contains_values(
             &registry,
             default_storage_name,
-            &events[1].clone().outputs().unwrap(),
+            &events[1].clone().outputs()[0],
             json!({"value": 4}),
         );
 
@@ -582,7 +582,7 @@ mod tests {
         assert_registry_contains_values(
             &registry,
             default_storage_name,
-            &events[1].clone().outputs().unwrap(),
+            &events[1].clone().outputs()[0],
             json!({"value": 4}),
         );
 
@@ -631,11 +631,11 @@ mod tests {
         let events = stream.take(4).collect::<Vec<_>>().await;
         assert_eq!(events.len(), 4);
         assert!(events.contains(&Event::Node(NodeEvent {
-            loc: loc1.clone(),
+            locs: vec![loc1.clone()],
             status: NodeStatus::Running { state_update: None },
         })));
         assert!(events.contains(&Event::Node(NodeEvent {
-            loc: loc2.clone(),
+            locs: vec![loc2.clone()],
             status: NodeStatus::Running { state_update: None },
         })));
 
@@ -646,16 +646,16 @@ mod tests {
                 matches!(
                     event,
                     Event::Node(NodeEvent {
-                        loc,
+                        locs,
                         status: NodeStatus::Complete { .. }
-                    }) if loc == &loc1
+                    }) if locs == &vec![loc1.clone()]
                 )
             })
             .unwrap();
         assert_registry_contains_values(
             &registry,
             default_storage_name,
-            &complete0.clone().outputs().unwrap_or_default(),
+            &complete0.clone().outputs()[0],
             json!({"value": 4}),
         );
         let complete1 = events
@@ -664,16 +664,16 @@ mod tests {
                 matches!(
                     event,
                     Event::Node(NodeEvent {
-                        loc,
+                        locs,
                         status: NodeStatus::Complete { .. }
-                    }) if loc == &loc2
+                    }) if locs == &vec![loc2.clone()]
                 )
             })
             .unwrap();
         assert_registry_contains_values(
             &registry,
             default_storage_name,
-            &complete1.clone().outputs().unwrap_or_default(),
+            &complete1.clone().outputs()[0],
             json!({"value": 12}),
         );
 
@@ -720,7 +720,7 @@ mod tests {
         assert_registry_contains_values(
             &registry,
             "memory",
-            &events[1].clone().outputs().unwrap(),
+            &events[1].clone().outputs()[0],
             json!({"value": 4}),
         );
 
@@ -869,7 +869,7 @@ mod tests {
         assert_registry_contains_values(
             &registry,
             "memory",
-            &events[1].clone().outputs().unwrap(),
+            &events[1].clone().outputs()[0],
             json!({"value": 4}),
         );
 

--- a/tierkreis/src/executor/subprocess.rs
+++ b/tierkreis/src/executor/subprocess.rs
@@ -106,14 +106,14 @@ async fn process_finished_task(
                 let outputs =
                     transfer_assets(asset_storage_registry, &output_storage_name, &outputs);
                 match outputs {
-                    Ok(outputs) => send_complete(event_sender, loc, outputs).await?,
+                    Ok(outputs) => send_complete(event_sender, vec![loc], vec![outputs]).await?,
                     Err(err) => send_error(event_sender, loc, &err).await?,
                 }
             } else {
                 let stderr = background_task.stderr.await.ok();
                 event_sender
                     .send(Event::Node(NodeEvent {
-                        loc,
+                        locs: vec![loc],
                         status: NodeStatus::Error {
                             error: format!("Subprocess failed with exit code: {status}"),
                             detail: stderr,
@@ -576,7 +576,7 @@ mod tests {
         assert_registry_contains_values(
             &registry,
             output_storage_name,
-            &events[1].clone().outputs().unwrap_or_default(),
+            &events[1].clone().outputs()[0],
             json!({"value": "hello dave"}),
         );
 
@@ -633,7 +633,7 @@ mod tests {
         assert_registry_contains_values(
             &registry,
             output_storage_name,
-            &events[1].clone().outputs().unwrap_or_default(),
+            &events[1].clone().outputs()[0],
             json!({"value": "hello dave"}),
         );
 
@@ -689,11 +689,11 @@ mod tests {
         let events = stream.take(4).collect::<Vec<_>>().await;
         assert_eq!(events.len(), 4);
         assert!(events.contains(&Event::Node(NodeEvent {
-            loc: loc1.clone(),
+            locs: vec![loc1.clone()],
             status: NodeStatus::Running { state_update: None },
         })));
         assert!(events.contains(&Event::Node(NodeEvent {
-            loc: loc2.clone(),
+            locs: vec![loc2.clone()],
             status: NodeStatus::Running { state_update: None },
         })));
 
@@ -704,16 +704,16 @@ mod tests {
                 matches!(
                     event,
                     Event::Node(NodeEvent {
-                        loc,
+                        locs,
                         status: NodeStatus::Complete { .. }
-                    }) if loc == &loc1
+                    }) if locs == &vec![loc1.clone()]
                 )
             })
             .unwrap();
         assert_registry_contains_values(
             &registry,
             output_storage_name,
-            &complete0.clone().outputs().unwrap_or_default(),
+            &complete0.clone().outputs()[0],
             json!({"value": "hello dave"}),
         );
         let complete1 = events
@@ -722,16 +722,16 @@ mod tests {
                 matches!(
                     event,
                     Event::Node(NodeEvent {
-                        loc,
+                        locs,
                         status: NodeStatus::Complete { .. }
-                    }) if loc == &loc2
+                    }) if locs == &vec![loc2.clone()]
                 )
             })
             .unwrap();
         assert_registry_contains_values(
             &registry,
             output_storage_name,
-            &complete1.clone().outputs().unwrap_or_default(),
+            &complete1.clone().outputs()[0],
             json!({"value": "hi steve"}),
         );
 
@@ -783,7 +783,7 @@ mod tests {
         assert_registry_contains_values(
             &registry,
             "file",
-            &events[1].clone().outputs().unwrap_or_default(),
+            &events[1].clone().outputs()[0],
             json!({"value": "hello dave"}),
         );
 
@@ -941,7 +941,7 @@ mod tests {
         assert_registry_contains_values(
             &registry,
             "file",
-            &events[1].clone().outputs().unwrap_or_default(),
+            &events[1].clone().outputs()[0],
             json!({"value": "hello dave"}),
         );
 

--- a/tierkreis/src/orchestrator.rs
+++ b/tierkreis/src/orchestrator.rs
@@ -76,6 +76,8 @@ pub enum ActionKind {
     },
     /// Mark the node as partially complete for a particular element.
     SetMapElemComplete {
+        /// The size of the map.
+        size: usize,
         /// The map element to mark as complete.
         index: usize,
     },
@@ -86,6 +88,17 @@ pub enum ActionKind {
     },
     /// Mark the overall workflow as complete.
     WorkflowFinished {},
+}
+
+#[derive(Debug, Clone, Default)]
+struct ActionPlan {
+    tasks: Vec<TaskPlan>,
+    switching: Vec<(Location, bool)>,
+    looping: Vec<(Location, u32)>,
+    mapping: Vec<(Location, usize)>,
+    map_elem_complete: HashMap<Location, BitVec>,
+    node_complete: Vec<(Location, HashMap<String, AssetSpec>)>,
+    workflow_complete: bool,
 }
 
 /// The context state for the orchestration
@@ -396,15 +409,13 @@ impl Orchestrator {
         context: &OrchestrationContext,
         nodes: impl Iterator<Item = &NodeIndex>,
     ) -> miette::Result<()> {
-        for node in nodes {
-            context
-                .workflow_state
-                .write(Event::Node(NodeEvent {
-                    loc: context.parent_loc.with_node(*node),
-                    status: crate::event::NodeStatus::Scheduled {},
-                }))
-                .await?;
-        }
+        context
+            .workflow_state
+            .write(Event::Node(NodeEvent {
+                locs: nodes.map(|n| context.parent_loc.with_node(*n)).collect(),
+                status: crate::event::NodeStatus::Scheduled {},
+            }))
+            .await?;
 
         Ok(())
     }
@@ -799,6 +810,7 @@ impl Orchestrator {
         subgraph: Arc<WorkflowGraph>,
     ) -> miette::Result<LocalBoxStream<'_, miette::Result<Action>>> {
         let output_idx = subgraph.output_idx();
+        let map_size = completed.len();
 
         Ok(stream::iter(completed.into_iter().enumerate())
             .filter(|(_index, completed)| future::ready(!completed))
@@ -826,7 +838,10 @@ impl Orchestrator {
                             None => Ok(stream::empty().boxed()),
                             Some(_) => Ok(stream::once(future::ok(Action {
                                 loc: loc_copy,
-                                kind: ActionKind::SetMapElemComplete { index },
+                                kind: ActionKind::SetMapElemComplete {
+                                    index,
+                                    size: map_size,
+                                },
                             }))
                             .boxed()),
                         }
@@ -916,7 +931,7 @@ impl Orchestrator {
     ) -> miette::Result<()> {
         // Build a list of tasks to dispatch to Executors and immediately
         // process everything else.
-        let mut task_plans = Vec::new();
+        let mut plan = ActionPlan::default();
         let mut event_sender = self.event_sender.clone();
         while let Some(Action { loc, kind }) = actions.next().await.transpose()? {
             debug!("Running action at {loc}, kind: {kind:?}");
@@ -926,7 +941,7 @@ impl Orchestrator {
                     task_name,
                     inputs,
                     outputs,
-                } => task_plans.push(TaskPlan {
+                } => plan.tasks.push(TaskPlan {
                     loc,
                     worker_name,
                     task_name,
@@ -936,24 +951,46 @@ impl Orchestrator {
                     ..Default::default()
                 }),
                 ActionKind::SetSwitching { cond } => {
-                    send_running_switching(&mut event_sender, loc, cond).await?;
+                    plan.switching.push((loc, cond));
                 }
                 ActionKind::SetRunningLoop { index } => {
-                    send_running_loop(&mut event_sender, loc, index).await?;
+                    plan.looping.push((loc, index));
                 }
                 ActionKind::SetRunningMap { size } => {
-                    send_running_map(&mut event_sender, loc, size).await?;
+                    plan.mapping.push((loc, size));
                 }
-                ActionKind::SetMapElemComplete { index } => {
-                    send_map_elem_complete(&mut event_sender, loc, index).await?;
+                ActionKind::SetMapElemComplete { index, size } => {
+                    let entry = plan
+                        .map_elem_complete
+                        .entry(loc)
+                        .or_insert_with(|| BitVec::repeat(false, size));
+                    entry.set(index, true);
                 }
                 ActionKind::SetComplete { outputs } => {
-                    send_complete(&mut event_sender, loc, outputs).await?;
+                    plan.node_complete.push((loc, outputs));
                 }
                 ActionKind::WorkflowFinished {} => {
-                    send_workflow_run_complete(&mut event_sender).await?;
+                    plan.workflow_complete = true;
                 }
             }
+        }
+
+        if !plan.node_complete.is_empty() {
+            let (locs, outputs) = plan.node_complete.into_iter().unzip();
+            send_complete(&mut event_sender, locs, outputs).await?;
+        }
+
+        for (loc, size) in plan.mapping {
+            send_running_map(&mut event_sender, loc, size).await?;
+        }
+        for (loc, bits) in plan.map_elem_complete {
+            send_map_elem_complete(&mut event_sender, loc, bits).await?;
+        }
+        for (loc, index) in plan.looping {
+            send_running_loop(&mut event_sender, loc, index).await?;
+        }
+        for (loc, cond) in plan.switching {
+            send_running_switching(&mut event_sender, loc, cond).await?;
         }
 
         let default_executor_name = &self.default_executor_name;
@@ -962,9 +999,13 @@ impl Orchestrator {
             .get(default_executor_name)
             .ok_or_else(|| miette!("Could not find a storage with name '{default_executor_name}' in ExecutorRegistry")).wrap_err("Could not run Task Nodes")?;
         executor
-            .execute(task_plans)
+            .execute(plan.tasks)
             .await
             .wrap_err_with(|| miette!("Could not run Task Nodes"))?;
+
+        if plan.workflow_complete {
+            send_workflow_run_complete(&mut event_sender).await?;
+        }
 
         Ok(())
     }
@@ -1287,11 +1328,34 @@ mod tests {
         wf
     }
 
+    async fn next_actions(
+        orchestrator: &Orchestrator,
+        workflow_graph: &Arc<WorkflowGraph>,
+        workflow_state: &Arc<dyn WorkflowState>,
+        inputs: &HashMap<String, AssetSpec>,
+    ) -> miette::Result<Vec<Action>> {
+        let context = OrchestrationContext {
+            parent_loc: Location::root(),
+            graph_inputs: inputs.clone(),
+            workflow_state: Arc::clone(workflow_state),
+        };
+        let actions = orchestrator
+            .build_actions(context, Arc::clone(workflow_graph))
+            .await?;
+        let actions = actions
+            .collect::<Vec<Result<_, _>>>()
+            .await
+            .into_iter()
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(actions)
+    }
+
     // Test that we can plan a workflow with two input nodes.
     #[rstest]
     #[case::memory("memory")]
     #[case::file("file")]
     #[tokio::test]
+    #[test_log::test]
     async fn plan_two_input_workflow(
         #[case] default_storage_name: &str,
         two_inputs_two_outputs: WorkflowGraph,
@@ -1311,21 +1375,12 @@ mod tests {
         let (workflow_state, _state_events) = InMemoryWorkflowState::test();
         let workflow_state: Arc<dyn WorkflowState> = Arc::new(workflow_state);
         let inputs = input_sets[0].clone();
-        let context = OrchestrationContext {
-            parent_loc: Location::root(),
-            graph_inputs: inputs.clone(),
-            workflow_state,
-        };
-        let actions = orchestrator
-            .build_actions(context, workflow_graph.clone())
-            .await?;
-        let actions = actions.collect::<Vec<_>>().await;
+        let actions =
+            next_actions(&orchestrator, &workflow_graph, &workflow_state, &inputs).await?;
 
         assert_eq!(actions.len(), 2);
-        let action0 = actions[0].as_ref().unwrap();
-        assert!(matches!(action0.kind, ActionKind::SetComplete { .. }));
-        let action1 = actions[1].as_ref().unwrap();
-        assert!(matches!(action1.kind, ActionKind::SetComplete { .. }));
+        assert!(matches!(actions[0].kind, ActionKind::SetComplete { .. }));
+        assert!(matches!(actions[1].kind, ActionKind::SetComplete { .. }));
 
         Ok(())
     }
@@ -1335,6 +1390,7 @@ mod tests {
     #[case::memory("memory")]
     #[case::file("file")]
     #[tokio::test]
+    #[test_log::test]
     async fn plan_and_run_simple_io_workflow(
         #[case] default_storage_name: &str,
         one_input_one_output: WorkflowGraph,
@@ -1353,63 +1409,50 @@ mod tests {
         let inputs = input_sets[0].clone();
         let (workflow_state, _state_events) = InMemoryWorkflowState::test();
         let workflow_state: Arc<dyn WorkflowState> = Arc::new(workflow_state);
-        let context = OrchestrationContext {
-            parent_loc: Location::root(),
-            graph_inputs: inputs.clone(),
-            workflow_state: Arc::clone(&workflow_state),
-        };
-        let actions = orchestrator
-            .build_actions(context, workflow_graph.clone())
-            .await?;
-        let actions = actions.collect::<Vec<_>>().await;
+        let actions =
+            next_actions(&orchestrator, &workflow_graph, &workflow_state, &inputs).await?;
 
         assert_eq!(actions.len(), 1);
-        let action0 = actions[0].as_ref().unwrap();
-        assert_eq!(action0.loc, Location::new("N1")?);
-        assert!(matches!(action0.kind, ActionKind::SetComplete { .. }));
+        assert_eq!(actions[0].loc, Location::new("N1")?);
+        assert!(matches!(actions[0].kind, ActionKind::SetComplete { .. }));
 
-        orchestrator.perform_actions(stream::iter(actions)).await?;
+        orchestrator
+            .perform_actions(stream::iter(actions.into_iter().map(Ok)))
+            .await?;
         let input_complete_event = stream.next().await.unwrap();
-        let input_complete_outputs = input_complete_event.clone().outputs().unwrap();
+        let input_complete_outputs = input_complete_event.clone().outputs();
         assert_registry_contains_values(
             &registry,
             "memory", // Asset is not modified so it remains in memory.
-            &input_complete_outputs,
+            &input_complete_outputs[0],
             json!({"a": 1}),
         );
 
         workflow_state.write(input_complete_event).await?;
-        let context = OrchestrationContext {
-            parent_loc: Location::root(),
-            graph_inputs: inputs.clone(),
-            workflow_state: Arc::clone(&workflow_state),
-        };
-        let actions = orchestrator
-            .build_actions(context, workflow_graph.clone())
-            .await?;
-        let actions = actions.collect::<Vec<_>>().await;
+        let actions =
+            next_actions(&orchestrator, &workflow_graph, &workflow_state, &inputs).await?;
 
         assert_eq!(actions.len(), 2);
-        let action0 = actions[0].as_ref().unwrap();
         assert_eq!(
-            action0.loc,
+            actions[0].loc,
             Location::from_node_index_iter([workflow_graph.output_idx()])
         );
-        assert!(matches!(action0.kind, ActionKind::SetComplete { .. }));
-        let action1 = actions[1].as_ref().unwrap();
+        assert!(matches!(actions[0].kind, ActionKind::SetComplete { .. }));
         assert_eq!(
-            action1.loc,
+            actions[1].loc,
             Location::from_node_index_iter([workflow_graph.output_idx()])
         );
-        assert!(matches!(action1.kind, ActionKind::WorkflowFinished {}));
+        assert!(matches!(actions[1].kind, ActionKind::WorkflowFinished {}));
 
-        orchestrator.perform_actions(stream::iter(actions)).await?;
+        orchestrator
+            .perform_actions(stream::iter(actions.into_iter().map(Ok)))
+            .await?;
         let output_complete_event = stream.next().await.unwrap();
-        let output_complete_outputs = output_complete_event.outputs().unwrap();
+        let output_complete_outputs = output_complete_event.outputs();
         assert_registry_contains_values(
             &registry,
             "memory", // Asset is not modified so it remains in memory.
-            &output_complete_outputs,
+            &output_complete_outputs[0],
             json!({"out": 1}),
         );
 
@@ -1421,6 +1464,7 @@ mod tests {
     #[case::memory("memory")]
     #[case::file("file")]
     #[tokio::test]
+    #[test_log::test]
     async fn plan_and_run_simple_eval_workflow(
         #[case] default_storage_name: &str,
         one_input_one_output: WorkflowGraph,
@@ -1444,120 +1488,91 @@ mod tests {
         let (workflow_state, _state_events) = InMemoryWorkflowState::test();
         let workflow_state: Arc<dyn WorkflowState> = Arc::new(workflow_state);
         let inputs = input_sets[0].clone();
-        let context = OrchestrationContext {
-            parent_loc: Location::root(),
-            graph_inputs: inputs.clone(),
-            workflow_state: Arc::clone(&workflow_state),
-        };
-        let actions = orchestrator
-            .build_actions(context, workflow_graph.clone())
-            .await?;
-        let actions = actions.collect::<Vec<_>>().await;
+        let actions =
+            next_actions(&orchestrator, &workflow_graph, &workflow_state, &inputs).await?;
 
         assert_eq!(actions.len(), 2);
-        let action0 = actions[0].as_ref().unwrap();
-        assert_eq!(action0.loc, Location::new("N2")?);
-        assert!(matches!(action0.kind, ActionKind::SetComplete { .. }));
-        let action1 = actions[1].as_ref().unwrap();
-        assert_eq!(action1.loc, Location::new("N1")?);
-        assert!(matches!(action1.kind, ActionKind::SetComplete { .. }));
+        assert_eq!(actions[0].loc, Location::new("N2")?);
+        assert!(matches!(actions[0].kind, ActionKind::SetComplete { .. }));
+        assert_eq!(actions[1].loc, Location::new("N1")?);
+        assert!(matches!(actions[1].kind, ActionKind::SetComplete { .. }));
 
-        orchestrator.perform_actions(stream::iter(actions)).await?;
-        let subworkflow_input_complete_event = stream.next().await.unwrap();
-        let subworkflow_input_complete_outputs =
-            subworkflow_input_complete_event.clone().outputs().unwrap();
+        orchestrator
+            .perform_actions(stream::iter(actions.into_iter().map(Ok)))
+            .await?;
+
+        let inputs_complete_event = stream.next().await.unwrap();
+        let inputs_complete_outputs = inputs_complete_event.clone().outputs();
         assert_registry_contains_values(
             &registry,
             "memory", // Asset is not modified so it remains in memory.
-            &subworkflow_input_complete_outputs,
+            &inputs_complete_outputs[0],
             json!({"subworkflow": one_input_one_output}),
         );
-
-        let a_input_complete_event = stream.next().await.unwrap();
-        let a_input_complete_outputs = a_input_complete_event.clone().outputs().unwrap();
         assert_registry_contains_values(
             &registry,
             "memory", // Asset is not modified so it remains in memory.
-            &a_input_complete_outputs,
+            &inputs_complete_outputs[1],
             json!({"a": 1}),
         );
 
-        workflow_state
-            .write(subworkflow_input_complete_event)
-            .await?;
-        workflow_state.write(a_input_complete_event).await?;
-        let context = OrchestrationContext {
-            parent_loc: Location::root(),
-            graph_inputs: inputs.clone(),
-            workflow_state: Arc::clone(&workflow_state),
-        };
-        let actions = orchestrator
-            .build_actions(context, workflow_graph.clone())
-            .await?;
-        let actions = actions.collect::<Vec<_>>().await;
+        workflow_state.write(inputs_complete_event).await?;
+
+        let actions =
+            next_actions(&orchestrator, &workflow_graph, &workflow_state, &inputs).await?;
 
         assert_eq!(actions.len(), 1);
-        let action0 = actions[0].as_ref().unwrap();
-        assert_eq!(action0.loc, Location::new("N3.N1")?);
-        assert!(matches!(action0.kind, ActionKind::SetComplete { .. }));
+        assert_eq!(actions[0].loc, Location::new("N3.N1")?);
+        assert!(matches!(actions[0].kind, ActionKind::SetComplete { .. }));
 
-        orchestrator.perform_actions(stream::iter(actions)).await?;
-        let inner_a_input_complete_event = stream.next().await.unwrap();
-        let inner_a_input_complete_outputs =
-            inner_a_input_complete_event.clone().outputs().unwrap();
+        orchestrator
+            .perform_actions(stream::iter(actions.into_iter().map(Ok)))
+            .await?;
+        let inner_inputs_complete_event = stream.next().await.unwrap();
+        let inner_inputs_complete_outputs = inner_inputs_complete_event.clone().outputs();
         assert_registry_contains_values(
             &registry,
             "memory", // Asset is not modified so it remains in memory.
-            &inner_a_input_complete_outputs,
+            &inner_inputs_complete_outputs[0],
             json!({"a": 1}),
         );
 
-        workflow_state.write(inner_a_input_complete_event).await?;
-        let context = OrchestrationContext {
-            parent_loc: Location::root(),
-            graph_inputs: inputs.clone(),
-            workflow_state: Arc::clone(&workflow_state),
-        };
-        let actions = orchestrator
-            .build_actions(context, workflow_graph.clone())
-            .await?;
-        let actions = actions.collect::<Vec<_>>().await;
+        workflow_state.write(inner_inputs_complete_event).await?;
+        let actions =
+            next_actions(&orchestrator, &workflow_graph, &workflow_state, &inputs).await?;
 
-        orchestrator.perform_actions(stream::iter(actions)).await?;
+        orchestrator
+            .perform_actions(stream::iter(actions.into_iter().map(Ok)))
+            .await?;
         let inner_output_complete_event = stream.next().await.unwrap();
-        let inner_output_complete_outputs = inner_output_complete_event.clone().outputs().unwrap();
+        let inner_output_complete_outputs = inner_output_complete_event.clone().outputs();
         assert_registry_contains_values(
             &registry,
             "memory", // Asset is not modified so it remains in memory.
-            &inner_output_complete_outputs,
+            &inner_output_complete_outputs[0],
             json!({"out": 1}),
         );
 
         let eval_complete_event = Event::Node(NodeEvent {
-            loc: Location::new("N3")?,
+            locs: vec![Location::new("N3")?],
             status: NodeStatus::Complete {
-                outputs: inner_output_complete_outputs.clone(),
+                outputs: inner_output_complete_outputs,
             },
         });
         workflow_state.write(inner_output_complete_event).await?;
         workflow_state.write(eval_complete_event).await?;
-        let context = OrchestrationContext {
-            parent_loc: Location::root(),
-            graph_inputs: inputs.clone(),
-            workflow_state: Arc::clone(&workflow_state),
-        };
-        let actions = orchestrator
-            .build_actions(context, workflow_graph.clone())
-            .await?;
-        let actions = actions.collect::<Vec<_>>().await;
+        let actions =
+            next_actions(&orchestrator, &workflow_graph, &workflow_state, &inputs).await?;
 
-        orchestrator.perform_actions(stream::iter(actions)).await?;
+        orchestrator
+            .perform_actions(stream::iter(actions.into_iter().map(Ok)))
+            .await?;
         let output_complete_event = stream.next().await.unwrap();
-        let output_complete_outputs = output_complete_event.outputs().unwrap();
+        let output_complete_outputs = output_complete_event.outputs();
         assert_registry_contains_values(
             &registry,
             "memory", // Asset is not modified so it remains in memory.
-            &output_complete_outputs,
+            &output_complete_outputs[0],
             json!({"out": 1}),
         );
 
@@ -1568,7 +1583,8 @@ mod tests {
     #[rstest]
     #[case::memory("memory")]
     #[case::file("file")]
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    #[tokio::test]
+    #[test_log::test]
     async fn run_simple_task_workflow(
         #[case] default_storage_name: &str,
         simple_task: WorkflowGraph,
@@ -1654,7 +1670,8 @@ mod tests {
     #[rstest]
     #[case::memory("memory")]
     #[case::file("file")]
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    #[tokio::test]
+    #[test_log::test]
     async fn run_simple_eval_workflow(
         #[case] default_storage_name: &str,
         one_input_one_output: WorkflowGraph,

--- a/tierkreis/src/state/inmemory.rs
+++ b/tierkreis/src/state/inmemory.rs
@@ -7,6 +7,7 @@ state is not persisted beyond the lifetime of the process.
 */
 use std::{
     collections::HashMap,
+    ops::BitOrAssign,
     sync::{Arc, Mutex},
 };
 
@@ -241,77 +242,82 @@ fn handle_node_event(
     send_update: &mut bool,
     node_event: NodeEvent,
 ) {
-    let node_state = run_state.nodes.entry(node_event.loc).or_default();
-    match node_event.status {
-        crate::event::NodeStatus::Scheduled => {
-            if node_state.scheduled_time.is_none() {
-                *send_update = true;
-                node_state.scheduled_time = Some(Utc::now());
+    for (idx, loc) in node_event.locs.into_iter().enumerate() {
+        let node_state = run_state.nodes.entry(loc).or_default();
+        match node_event.status {
+            crate::event::NodeStatus::Scheduled => {
+                if node_state.scheduled_time.is_none() {
+                    *send_update = true;
+                    node_state.scheduled_time = Some(Utc::now());
+                }
             }
-        }
-        crate::event::NodeStatus::Queued => {
-            if node_state.queued_time.is_none() {
-                *send_update = true;
-                node_state.queued_time = Some(Utc::now());
+            crate::event::NodeStatus::Queued => {
+                if node_state.queued_time.is_none() {
+                    *send_update = true;
+                    node_state.queued_time = Some(Utc::now());
+                }
             }
-        }
-        crate::event::NodeStatus::Running { state_update: None } => {
-            if node_state.running_time.is_none() {
-                *send_update = true;
-                node_state.running_time = Some(Utc::now());
+            crate::event::NodeStatus::Running { state_update: None } => {
+                if node_state.running_time.is_none() {
+                    *send_update = true;
+                    node_state.running_time = Some(Utc::now());
+                }
             }
-        }
-        crate::event::NodeStatus::Running {
-            state_update: Some(RunningStateUpdate::Switching { cond }),
-        } => {
-            if node_state.cond.is_none() {
-                *send_update = true;
-                node_state.cond = Some(cond);
+            crate::event::NodeStatus::Running {
+                state_update: Some(RunningStateUpdate::Switching { cond }),
+            } => {
+                if node_state.cond.is_none() {
+                    *send_update = true;
+                    node_state.cond = Some(cond);
+                }
             }
-        }
-        crate::event::NodeStatus::Running {
-            state_update: Some(RunningStateUpdate::Looping { index }),
-        } => {
-            if node_state.loop_index != Some(index) {
-                *send_update = true;
-                node_state.loop_index = Some(index);
+            crate::event::NodeStatus::Running {
+                state_update: Some(RunningStateUpdate::Looping { index }),
+            } => {
+                if node_state.loop_index != Some(index) {
+                    *send_update = true;
+                    node_state.loop_index = Some(index);
+                }
             }
-        }
-        crate::event::NodeStatus::Running {
-            state_update: Some(RunningStateUpdate::MapStarted { size }),
-        } => {
-            if node_state.map_completed.is_none() {
-                *send_update = true;
-                node_state.map_completed = Some(BitVec::repeat(false, size as usize));
+            crate::event::NodeStatus::Running {
+                state_update: Some(RunningStateUpdate::MapStarted { size }),
+            } => {
+                if node_state.map_completed.is_none() {
+                    *send_update = true;
+                    node_state.map_completed = Some(BitVec::repeat(false, size as usize));
+                }
             }
-        }
-        crate::event::NodeStatus::Running {
-            state_update: Some(RunningStateUpdate::MapElemComplete { index }),
-        } => {
-            if let Some(map_completed) = node_state.map_completed.as_mut() {
-                map_completed.set(index as usize, true);
-                *send_update = true;
+            crate::event::NodeStatus::Running {
+                state_update: Some(RunningStateUpdate::MapElemComplete { ref bits }),
+            } => {
+                if let Some(map_completed) = node_state.map_completed.as_mut() {
+                    map_completed.bitor_assign(bits);
+                    *send_update = true;
+                }
             }
-        }
-        crate::event::NodeStatus::Complete { outputs } => {
-            if node_state.complete_time.is_none() {
-                *send_update = true;
-                node_state.complete_time = Some(Utc::now());
-                node_state.outputs = Some(outputs);
+            crate::event::NodeStatus::Complete { ref outputs } => {
+                if node_state.complete_time.is_none() {
+                    *send_update = true;
+                    node_state.complete_time = Some(Utc::now());
+                    node_state.outputs = Some(outputs.get(idx).unwrap().clone());
+                }
             }
-        }
-        crate::event::NodeStatus::Cancelled => {
-            if node_state.cancelled_time.is_none() {
-                *send_update = true;
-                node_state.cancelled_time = Some(Utc::now());
+            crate::event::NodeStatus::Cancelled => {
+                if node_state.cancelled_time.is_none() {
+                    *send_update = true;
+                    node_state.cancelled_time = Some(Utc::now());
+                }
             }
-        }
-        crate::event::NodeStatus::Error { error, detail } => {
-            if node_state.error_time.is_none() {
-                *send_update = true;
-                node_state.error_time = Some(Utc::now());
-                node_state.error = Some(error);
-                node_state.error_detail = detail;
+            crate::event::NodeStatus::Error {
+                ref error,
+                ref detail,
+            } => {
+                if node_state.error_time.is_none() {
+                    *send_update = true;
+                    node_state.error_time = Some(Utc::now());
+                    node_state.error = Some(error.clone());
+                    node_state.error_detail.clone_from(detail);
+                }
             }
         }
     }
@@ -352,7 +358,7 @@ mod tests {
 
         workflow_state
             .write(Event::Node(NodeEvent {
-                loc: Location::root(),
+                locs: vec![Location::root()],
                 status: NodeStatus::Scheduled,
             }))
             .await?;
@@ -382,7 +388,7 @@ mod tests {
 
         workflow_state
             .write(Event::Node(NodeEvent {
-                loc: Location::root(),
+                locs: vec![Location::root()],
                 status: NodeStatus::Scheduled,
             }))
             .await?;

--- a/tierkreis/src/state/queries.rs
+++ b/tierkreis/src/state/queries.rs
@@ -3,6 +3,7 @@ This module defines the queries for reading the workflow state from the `SQlite`
 */
 use std::collections::HashMap;
 use std::hash::BuildHasher;
+use std::ops::BitOr;
 
 use bitvec::vec::BitVec;
 use chrono::{DateTime, NaiveDateTime, Utc};
@@ -255,8 +256,8 @@ pub fn set_error_if_none(
     loc: &Location,
     run_id: uuid::Uuid,
     attempt: u32,
-    error: String,
-    detail: Option<String>,
+    error: &str,
+    detail: Option<&str>,
     connection: &Pool<ConnectionManager<SqliteConnection>>,
 ) -> miette::Result<bool> {
     use crate::state::schema::node_states::dsl as ns;
@@ -425,7 +426,7 @@ pub fn set_map_elem_complete(
     loc: &Location,
     run_id: uuid::Uuid,
     attempt: u32,
-    index: u32,
+    completed: &BitVec,
     connection: &Pool<ConnectionManager<SqliteConnection>>,
 ) -> miette::Result<bool> {
     use crate::state::schema::node_states::dsl as ns;
@@ -457,22 +458,13 @@ pub fn set_map_elem_complete(
         return Ok(false);
     };
 
-    let mut map_completed = decode_map_completed(&encoded)?;
-    let index_usize = usize::try_from(index)
-        .into_diagnostic()
-        .wrap_err_with(|| miette!("Map completion index {index} does not fit into usize"))?;
-    if index_usize >= map_completed.len() {
-        return Err(miette!(
-            "Map completion index {index} out of bounds for map of size {}",
-            map_completed.len()
-        ));
-    }
-    if map_completed[index_usize] {
+    let map_completed = decode_map_completed(&encoded)?;
+    let new_map_completed = map_completed.bitor(completed);
+    if new_map_completed == *completed {
         return Ok(false);
     }
 
-    map_completed.set(index_usize, true);
-    let updated = encode_map_completed(&map_completed)?;
+    let updated = encode_map_completed(&new_map_completed)?;
     let changed = diesel::update(
         ns::node_states
             .filter(ns::run_id.eq(run_id.to_string()))

--- a/tierkreis/src/state/sql.rs
+++ b/tierkreis/src/state/sql.rs
@@ -291,46 +291,63 @@ impl SqliteWorkflowState {
     }
 
     fn handle_node_event(&self, event: NodeEvent, send_update: &mut bool) -> miette::Result<()> {
-        let loc = event.loc.clone();
-        insert_default_node_state(&loc, self.run_id, self.attempt, &self.global_state)?;
+        // TODO: This should not be a loop at all.
+        for loc in event.locs {
+            insert_default_node_state(&loc, self.run_id, self.attempt, &self.global_state)?;
 
-        *send_update = match event.status {
-            NodeStatus::Scheduled => {
-                set_scheduled_if_none(&loc, self.run_id, self.attempt, &self.global_state)
-            }
-            NodeStatus::Queued => {
-                set_queued_if_none(&loc, self.run_id, self.attempt, &self.global_state)
-            }
-            NodeStatus::Running { state_update: None } => {
-                set_running_if_none(&loc, self.run_id, self.attempt, &self.global_state)
-            }
-            NodeStatus::Running {
-                state_update: Some(RunningStateUpdate::Switching { cond }),
-            } => set_cond_if_none(&loc, self.run_id, self.attempt, cond, &self.global_state),
-            NodeStatus::Running {
-                state_update: Some(RunningStateUpdate::Looping { index }),
-            } => set_loop_index(&loc, self.run_id, self.attempt, index, &self.global_state),
-            NodeStatus::Running {
-                state_update: Some(RunningStateUpdate::MapStarted { size }),
-            } => set_map_started_if_none(&loc, self.run_id, self.attempt, size, &self.global_state),
-            NodeStatus::Running {
-                state_update: Some(RunningStateUpdate::MapElemComplete { index }),
-            } => set_map_elem_complete(&loc, self.run_id, self.attempt, index, &self.global_state),
-            NodeStatus::Complete { outputs: _ } => {
-                set_complete_if_none(&loc, self.run_id, self.attempt, &self.global_state)
-            }
-            NodeStatus::Cancelled => {
-                set_cancelled_if_none(&loc, self.run_id, self.attempt, &self.global_state)
-            }
-            NodeStatus::Error { error, detail } => set_error_if_none(
-                &loc,
-                self.run_id,
-                self.attempt,
-                error,
-                detail,
-                &self.global_state,
-            ),
-        }?;
+            *send_update = match event.status {
+                NodeStatus::Scheduled => {
+                    set_scheduled_if_none(&loc, self.run_id, self.attempt, &self.global_state)
+                }
+                NodeStatus::Queued => {
+                    set_queued_if_none(&loc, self.run_id, self.attempt, &self.global_state)
+                }
+                NodeStatus::Running { state_update: None } => {
+                    set_running_if_none(&loc, self.run_id, self.attempt, &self.global_state)
+                }
+                NodeStatus::Running {
+                    state_update: Some(RunningStateUpdate::Switching { cond }),
+                } => set_cond_if_none(&loc, self.run_id, self.attempt, cond, &self.global_state),
+                NodeStatus::Running {
+                    state_update: Some(RunningStateUpdate::Looping { index }),
+                } => set_loop_index(&loc, self.run_id, self.attempt, index, &self.global_state),
+                NodeStatus::Running {
+                    state_update: Some(RunningStateUpdate::MapStarted { size }),
+                } => set_map_started_if_none(
+                    &loc,
+                    self.run_id,
+                    self.attempt,
+                    size,
+                    &self.global_state,
+                ),
+                NodeStatus::Running {
+                    state_update: Some(RunningStateUpdate::MapElemComplete { ref bits }),
+                } => set_map_elem_complete(
+                    &loc,
+                    self.run_id,
+                    self.attempt,
+                    &bits,
+                    &self.global_state,
+                ),
+                NodeStatus::Complete { outputs: _ } => {
+                    set_complete_if_none(&loc, self.run_id, self.attempt, &self.global_state)
+                }
+                NodeStatus::Cancelled => {
+                    set_cancelled_if_none(&loc, self.run_id, self.attempt, &self.global_state)
+                }
+                NodeStatus::Error {
+                    ref error,
+                    ref detail,
+                } => set_error_if_none(
+                    &loc,
+                    self.run_id,
+                    self.attempt,
+                    error,
+                    detail.as_deref(),
+                    &self.global_state,
+                ),
+            }?;
+        }
         Ok(())
     }
 }
@@ -371,7 +388,7 @@ mod tests {
 
         workflow_state
             .write(Event::Node(NodeEvent {
-                loc: Location::root(),
+                locs: vec![Location::root()],
                 status: NodeStatus::Scheduled,
             }))
             .await?;
@@ -401,7 +418,7 @@ mod tests {
 
         workflow_state
             .write(Event::Node(NodeEvent {
-                loc: Location::root(),
+                locs: vec![Location::root()],
                 status: NodeStatus::Scheduled,
             }))
             .await?;

--- a/tierkreis/src/state/sql.rs
+++ b/tierkreis/src/state/sql.rs
@@ -322,13 +322,9 @@ impl SqliteWorkflowState {
                 ),
                 NodeStatus::Running {
                     state_update: Some(RunningStateUpdate::MapElemComplete { ref bits }),
-                } => set_map_elem_complete(
-                    &loc,
-                    self.run_id,
-                    self.attempt,
-                    &bits,
-                    &self.global_state,
-                ),
+                } => {
+                    set_map_elem_complete(&loc, self.run_id, self.attempt, bits, &self.global_state)
+                }
                 NodeStatus::Complete { outputs: _ } => {
                     set_complete_if_none(&loc, self.run_id, self.attempt, &self.global_state)
                 }

--- a/tierkreis/src/updater.rs
+++ b/tierkreis/src/updater.rs
@@ -63,7 +63,7 @@ mod tests {
 
         let stream = once(async {
             Event::Node(NodeEvent {
-                loc: Location::from_usize_iter([0]),
+                locs: vec![Location::from_usize_iter([0])],
                 status: NodeStatus::Running { state_update: None },
             })
         })


### PR DESCRIPTION
Changes events to cover multiple locations and introduces an `ActionPlan`
struct that can be used as a basis for an independent planning step.

This should reduce the volume of events being produced which should
be a band aid for a potential deadlock when channels fill up, but
further improvements should be made in this area still.