### PR TITLE
chore: Change complex serialization format

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -62,7 +62,7 @@ in
       export MATURIN_NO_PROGRESS=1
       export RUST_LOG=error
     '' else ''
-      export LD_LIBRARY_PATH=${pkgs.stdenv.cc.cc.lib}/lib:$LD_LIBRARY_PATH
+      export LD_LIBRARY_PATH=${pkgs.stdenv.cc.cc.lib}/lib:${pkgs.zlib}/lib:$LD_LIBRARY_PATH
       export MATURIN_NO_PROGRESS=1
       export RUST_LOG=error
     '';

--- a/docs/justfile
+++ b/docs/justfile
@@ -1,4 +1,4 @@
-sphinx_opts  := ""
+sphinx_opts  := "-T"
 sphinx_build := "uv run sphinx-build"
 source_dir   := "source"
 build_dir    := "build"

--- a/tierkreis/tests/controller/test_resume.py
+++ b/tierkreis/tests/controller/test_resume.py
@@ -187,7 +187,7 @@ storage_ids = ["FileStorage", "In-memory"]
 )
 def test_resume(  # noqa: PLR0913
     storage_class: type[ControllerFileStorage | ControllerInMemoryStorage],
-    graph: GraphData,
+    graph: GraphData | Workflow,
     output: dict[str, PType] | PType,
     name: str,
     workflow_id: int,

--- a/tierkreis/tests/controller/test_types.py
+++ b/tierkreis/tests/controller/test_types.py
@@ -99,6 +99,7 @@ ptypes: Sequence[PType] = [
     DummyDictConvertible(a=11),
     DummyListConvertible(a=5),
     DummyBaseModel(a=5, b=b"some bytes"),
+    complex(1, -1),
 ]
 
 

--- a/tierkreis/tests/executor/test_executors.py
+++ b/tierkreis/tests/executor/test_executors.py
@@ -43,7 +43,7 @@ def test_shell_executor():
     storage.clean_graph_files()
     run_graph(storage, executor, g, {"value": "world"})
     actual_output = read_outputs(g, storage)
-    assert actual_output == b'Hello "world"\n'
+    assert actual_output == "Hello world"
     assert storage._exec_data_path(Loc()).parent.exists()
     node_loc = Loc("-.N1")
     data = storage.read_executor_data()
@@ -66,7 +66,7 @@ def test_suppress_env():
     storage.clean_graph_files()
     run_graph(storage, executor, g, {"value": "world"})
     actual_output = read_outputs(g, storage)
-    assert actual_output == b'Hello "world"\n'
+    assert actual_output == "Hello world"
     assert storage._exec_data_path(Loc()).parent.exists()
     node_loc = Loc("-.N1")
     data = storage.read_executor_data()
@@ -154,7 +154,7 @@ def test_stdinout_executor():
     storage.clean_graph_files()
     run_graph(storage, executor, g, {"value": "world"})
     actual_output = read_outputs(g, storage)
-    assert actual_output == b'Hello "world"\n'
+    assert actual_output == "Hello world"
     assert storage._exec_data_path(Loc()).parent.exists()
     node_loc = Loc("-.N1")
     data = storage.read_executor_data()
@@ -201,7 +201,7 @@ def test_task_executor():
     storage.clean_graph_files()
     run_graph(storage, executor, g, {"value": "world"})
     actual_output = read_outputs(g, storage)
-    assert actual_output == b'Goodbye cruel "world"\n'
+    assert actual_output == "Goodbye cruel world"
     assert storage._exec_data_path(Loc()).parent.exists()
     node_loc = Loc("-.N1")
     data = storage.read_executor_data()
@@ -253,7 +253,7 @@ def test_multiple_executor():
     storage.clean_graph_files()
     run_graph(storage, executor, g, {"value": "world"})
     actual_output = read_outputs(g, storage)
-    assert actual_output == b'Hello beautiful "world"\n'
+    assert actual_output == "Hello beautiful world"
     assert storage._exec_data_path(Loc()).parent.exists()
     node_loc = Loc("-.N1")
     data = storage.read_executor_data()

--- a/tierkreis/tests/workers/failing_worker/uv.lock
+++ b/tierkreis/tests/workers/failing_worker/uv.lock
@@ -177,7 +177,7 @@ provides-extras = ["hpc"]
 [package.metadata.requires-dev]
 build = [{ name = "build", extras = ["uv"] }]
 dev = [
-    { name = "guppylang" },
+    { name = "guppylang", specifier = ">=0.21.0" },
     { name = "ipykernel", specifier = ">=6.29.5" },
     { name = "pytest" },
     { name = "qnexus" },

--- a/tierkreis/tests/workers/hello_world_worker/uv.lock
+++ b/tierkreis/tests/workers/hello_world_worker/uv.lock
@@ -234,7 +234,7 @@ provides-extras = ["hpc"]
 [package.metadata.requires-dev]
 build = [{ name = "build", extras = ["uv"] }]
 dev = [
-    { name = "guppylang" },
+    { name = "guppylang", specifier = ">=0.21.0" },
     { name = "ipykernel", specifier = ">=6.29.5" },
     { name = "pytest" },
     { name = "qnexus" },

--- a/tierkreis/tests/workers/shell_worker/main.sh
+++ b/tierkreis/tests/workers/shell_worker/main.sh
@@ -1,4 +1,4 @@
 #! /usr/bin/env bash
 
-greeting=$(cat $input_greeting_file)
-echo $TEST_FLAG $greeting >> $output_value_file
+greeting=$(cat $input_greeting_file | tr -d '"')
+echo "\"$TEST_FLAG $greeting\"" >> $output_value_file

--- a/tierkreis/tests/workers/sleep_worker/uv.lock
+++ b/tierkreis/tests/workers/sleep_worker/uv.lock
@@ -202,7 +202,7 @@ provides-extras = ["hpc"]
 [package.metadata.requires-dev]
 build = [{ name = "build", extras = ["uv"] }]
 dev = [
-    { name = "guppylang" },
+    { name = "guppylang", specifier = ">=0.21.0" },
     { name = "ipykernel", specifier = ">=6.29.5" },
     { name = "pytest" },
     { name = "qnexus" },

--- a/tierkreis/tests/workers/stdinout_worker/main.sh
+++ b/tierkreis/tests/workers/stdinout_worker/main.sh
@@ -1,3 +1,3 @@
 #! /usr/bin/env bash
-in=$(cat)
-echo Hello $in
+in=$(cat | tr -d '"')
+echo "\"Hello $in\""

--- a/tierkreis/tierkreis/controller/data/types.py
+++ b/tierkreis/tierkreis/controller/data/types.py
@@ -368,8 +368,8 @@ def coerce_from_annotation[T: PType](ser: Any, annotation: type[T] | None) -> T 
         return ser
 
     if issubclass(origin, complex):
-        return complex(real=ser[0], imag=ser[1]) # type: ignore complex is T
-    
+        return complex(real=ser[0], imag=ser[1])  # type: ignore complex is T
+
     if origin is Package:
         return Package.from_bytes(ser)  # type: ignore Package is T
 

--- a/tierkreis/tierkreis/controller/data/types.py
+++ b/tierkreis/tierkreis/controller/data/types.py
@@ -399,6 +399,12 @@ def coerce_from_annotation[T: PType](ser: Any, annotation: type[T] | None) -> T 
         return annotation(coerce_from_annotation(ser, GraphData), outputs)  # type: ignore
 
     if issubclass(origin, Struct):
+        if isinstance(ser, Sequence):
+            xs = [
+                coerce_from_annotation(x, annotation)
+                for (x, annotation) in zip(ser, origin.__annotations__.values())
+            ]
+            return cast("T", origin(*xs))
         d = {
             k: coerce_from_annotation(ser[k], v)
             for k, v in origin.__annotations__.items()

--- a/tierkreis/tierkreis/controller/data/types.py
+++ b/tierkreis/tierkreis/controller/data/types.py
@@ -149,7 +149,7 @@ class TierkreisEncoder(json.JSONEncoder):
             return {"__tkr_bytes__": True, "bytes": b64encode(o).decode()}
 
         if isinstance(o, complex):
-            return {"__tkr_complex__": [o.real, o.imag]}
+            return [o.real, o.imag]
 
         return super().default(o)
 
@@ -165,9 +165,6 @@ class TierkreisDecoder(json.JSONDecoder):
         """Try to decode an object containing bytes."""
         if "__tkr_bytes__" in d and "bytes" in d:
             return b64decode(d["bytes"])
-
-        if "__tkr_complex__" in d:
-            return complex(*d["__tkr_complex__"])
 
         return d
 
@@ -367,8 +364,12 @@ def coerce_from_annotation[T: PType](ser: Any, annotation: type[T] | None) -> T 
         # just return the value in its "raw" form.
         return ser
 
-    if issubclass(origin, (bool, int, float, complex, str, bytes, NoneType)):
+    if issubclass(origin, (bool, int, float, str, bytes, NoneType)):
         return ser
+
+    if issubclass(origin, complex):
+        return complex(real=ser[0], imag=ser[1]) # type: ignore complex is T
+    
     if origin is Package:
         return Package.from_bytes(ser)  # type: ignore Package is T
 

--- a/tierkreis/tierkreis/storage.py
+++ b/tierkreis/tierkreis/storage.py
@@ -1,6 +1,7 @@
 """Implementation to access node storage data."""
 
 from typing import get_args, get_origin
+from typing_extensions import is_protocol
 
 from tierkreis.controller.data.graph import GraphData
 from tierkreis.controller.data.location import Loc
@@ -39,7 +40,7 @@ def _read_output(
         origin = get_origin(annotation)
         if origin is TKR:
             args = get_args(annotation)
-            if len(args) == 1 and is_ptype(args[0]):
+            if len(args) == 1 and is_ptype(args[0]) and not is_protocol(args[0]):
                 return ptype_from_bytes(storage.read_output(Loc(), port_name), args[0])
 
         return ptype_from_bytes(storage.read_output(Loc(), port_name))

--- a/tierkreis/tierkreis/storage.py
+++ b/tierkreis/tierkreis/storage.py
@@ -1,9 +1,16 @@
 """Implementation to access node storage data."""
 
+from typing import get_args, get_origin
+
 from tierkreis.controller.data.graph import GraphData
 from tierkreis.controller.data.location import Loc
-from tierkreis.controller.data.models import TModel
-from tierkreis.controller.data.types import PType, is_optional, ptype_from_bytes
+from tierkreis.controller.data.models import TKR, TModel
+from tierkreis.controller.data.types import (
+    PType,
+    is_optional,
+    is_ptype,
+    ptype_from_bytes,
+)
 from tierkreis.controller.storage.exceptions import EntryNotFoundError
 from tierkreis.controller.storage.filestorage import (
     ControllerFileStorage as FileStorage,
@@ -29,6 +36,12 @@ def _read_output(
     then do not raise on EntryNotFound.
     """
     try:
+        origin = get_origin(annotation)
+        if origin is TKR:
+            args = get_args(annotation)
+            if len(args) == 1 and is_ptype(args[0]):
+                return ptype_from_bytes(storage.read_output(Loc(), port_name), args[0])
+
         return ptype_from_bytes(storage.read_output(Loc(), port_name))
     except EntryNotFoundError as exc:
         if annotation and is_optional(annotation):


### PR DESCRIPTION
**Breaking** change the serialization format of complex numbers to the more conventional tuple of real and imaginary parts.

Also changes `get_outputs` to read the output annotation from Workflow graphs to allow direct deserialization into PTypes (including complex numbers)