### PR TITLE
chore: Disallow optional default inputs in graphs

### DIFF
--- a/tierkreis/src/orchestrator.rs
+++ b/tierkreis/src/orchestrator.rs
@@ -526,16 +526,11 @@ impl Orchestrator {
         loc: Location,
         name: &str,
     ) -> miette::Result<Action> {
-        let value = graph_inputs.get(name).cloned().unwrap_or_else(|| {
-            save_asset(
-                &self.asset_storage_registry,
-                &self.default_storage_name,
-                serde_json::to_vec(&serde_json::Value::Null).unwrap(),
-            )
-            .unwrap()
-        });
+        let value = graph_inputs
+            .get(name)
+            .ok_or_else(|| miette!("Input not found for port: {name}"))?;
         let mut outputs = HashMap::new();
-        outputs.insert(name.to_string(), value);
+        outputs.insert(name.to_string(), value.clone());
 
         Ok(Action {
             loc,

--- a/tierkreis/src/orchestrator.rs
+++ b/tierkreis/src/orchestrator.rs
@@ -223,7 +223,7 @@ impl Orchestrator {
                 let loc = parent_location.with_node(n);
                 match definition {
                     NodeDefinition::Input { name } => stream_action_result(
-                        self.build_input_action(graph_inputs.clone(), loc, name),
+                        Self::build_input_action(graph_inputs.clone(), loc, name),
                     ),
                     NodeDefinition::Const { value } => {
                         stream_action_result(self.build_const_action(loc, value.clone()))
@@ -519,9 +519,8 @@ impl Orchestrator {
         })
     }
 
-    #[instrument(skip(self, graph_inputs), fields(loc = %loc), err)]
+    #[instrument(skip(graph_inputs), fields(loc = %loc), err)]
     fn build_input_action(
-        &self,
         graph_inputs: Arc<HashMap<String, AssetSpec>>,
         loc: Location,
         name: &str,

--- a/tierkreis/tests/controller/test_resume.py
+++ b/tierkreis/tests/controller/test_resume.py
@@ -227,6 +227,10 @@ def test_runtime(  # noqa: PLR0913
         g = graph.data
     else:
         g = graph
+
+    if "defaults" in name:
+        pytest.skip("default arguments not supported")
+
     run_outputs = run_workflow(name, g, inputs)
     assert output == run_outputs
 


### PR DESCRIPTION
Revert change to support not passing inputs to graphs as it lead to potentially surprising behaviour. This functionality will need to be reviewed again for the new runtime.