### PR TITLE
fix: Additional checks to avoid running tasks

### DIFF
--- a/tierkreis/src/orchestrator.rs
+++ b/tierkreis/src/orchestrator.rs
@@ -343,7 +343,7 @@ impl Orchestrator {
             .toposort_filtered_from_output_node(
                 // Returns true if a node should be traversed.
                 |n| {
-                    let (_definition, state) = node_states
+                    let (definition, state) = node_states
                         .get(&n)
                         .expect("Node definition/state not found");
 
@@ -351,6 +351,13 @@ impl Orchestrator {
                     // are run multiple times if their state is yet
                     // to be updated from the last orchestration round.
                     state.outputs.is_none()
+                        && !(matches!(
+                            definition,
+                            NodeDefinition::Task { .. }
+                                | NodeDefinition::Input { .. }
+                                | NodeDefinition::Const { .. }
+                                | NodeDefinition::Output {}
+                        ) && state.scheduled_time.is_some())
                 },
                 // Returns true if a port should be traversed.
                 |n, p| {


### PR DESCRIPTION
This commit adds some extra checks during planning to avoid scheduling tasks twice by checking for a scheduled time as well as outputs for certain kinds of nodes. This isn't a perfect fix as there can be a delay in writing scheduled timestamps due to the updates being mediated by a channel.

Without this change running the subprocess executor can cause far too many subprocesses to be created.

See: https://github.com/Quantinuum/tierkreis/issues/514 for more details