### PR TITLE
chore: add new resource types to slurm

### DIFF
--- a/docs/source/executors/hpc.md
+++ b/docs/source/executors/hpc.md
@@ -47,6 +47,17 @@ The following resources can be specified:
 - Cores per node, how many cpus are assigned to a node
 - Memory, GBs of memory assigned to a node
 - GPUs, number of GPUs assigned to a node
+- **SLURM Only** QPUs, addressed by name (e.g. `"helios"`)
+- **SLURM Only** generic resources (gres), named general resources (e.g. `"gpu:tesla:2"`) 
+
+```{warning}
+Resources are defined by the administrators of the HPC site.
+This mainly affects QPUs and GPUs.
+This means that behavior can differ between sites.
+Make sure to read the appropriate documentation.
+
+For example, one site might specify `--qpus` as legal flag while others would use `--gres=qpu:1`.
+```
 
 ### User
 

--- a/tierkreis/tierkreis/controller/executor/hpc/job_spec.py
+++ b/tierkreis/tierkreis/controller/executor/hpc/job_spec.py
@@ -33,13 +33,17 @@ class ResourceSpec(BaseModel):
         nodes (int): Number of compute nodes, defaults to 1.
         cores_per_node (int | None): Number of cores to use per node, defaults to 1.
         memory_gb (int | None): Memory per node in GB, defaults to 4.
-        gpus_per_nod (int | None): Physical GPUs to reserve on the node, defaults to 0.
+        gpus_per_node (int | None): Physical GPUs to reserve on the node, defaults to 0.
+        qpus (list[str] | None): Named QPUs, defaults to None.
+        gres (list[str] | None): Generic resources to reserve on the node, defaults to None.
     """
 
     nodes: int = 1
     cores_per_node: int | None = 1
     memory_gb: int | None = 4
     gpus_per_node: int | None = 0
+    qpus: list[str] | None = None  # QRMI
+    gres: list[str] | None = None
 
 
 class UserSpec(BaseModel):

--- a/tierkreis/tierkreis/controller/executor/hpc/psij_conversion.py
+++ b/tierkreis/tierkreis/controller/executor/hpc/psij_conversion.py
@@ -72,6 +72,10 @@ def spec_to_psij(spec: JobSpec, target_scheduler: str | None = None) -> psij.Job
                 target_scheduler + "." + k.strip("-"): v
                 for k, v in spec.extra_scheduler_args.items()
             })
+    if spec.resource.gres and target_scheduler == "slurm":
+        custom_attrs[f"{target_scheduler}.gres"] = ",".join(spec.resource.gres)
+    if spec.resource.qpus and target_scheduler == "slurm":
+        custom_attrs[f"{target_scheduler}.qpu"] = ",".join(spec.resource.qpus)
 
     if spec.user and spec.user.mail:
         logger.warning("User email is not natively supported in psij.")
@@ -165,6 +169,13 @@ def psij_to_spec(psij_spec: psij.JobSpec) -> JobSpec:
         extra_args: dict[str, str | None] = {}
         if psij_spec.attributes.custom_attributes:
             for k, v in psij_spec.attributes.custom_attributes.items():
+                if k == "slurm.gres":
+                    resource.gres = str(v).split(",") if v else None
+                    continue
+                if k == "slurm.qpu":
+                    resource.qpus = str(v).split(",") if v else None
+                    continue
+
                 if k in ["slurm.mail-user", "pbs.m"]:
                     user = UserSpec(mail=str(v))
                     continue

--- a/tierkreis/tierkreis/controller/executor/hpc/slurm.py
+++ b/tierkreis/tierkreis/controller/executor/hpc/slurm.py
@@ -51,6 +51,11 @@ def generate_slurm_script(spec: JobSpec) -> str:  # noqa: C901, PLR0912 complexi
     if spec.queue is not None:
         lines.append(f"{_COMMAND_PREFIX} --partition={spec.queue}")
 
+    if spec.resource.gres is not None:
+        lines.append(f"{_COMMAND_PREFIX} --gres={','.join(spec.resource.gres)}")
+    if spec.resource.qpus is not None:
+        lines.append(f"{_COMMAND_PREFIX} --qpu={','.join(spec.resource.qpus)}")
+
     # 4. User settings
     lines.append("\n# --- User Details ---")
     if spec.account is not None:


### PR DESCRIPTION
Added qpus (QRMI variant) and gres resources.
slurm uses `--gres=name[[:type]:count]" so open to suggestions how to implement this

todos:
- docs
- psi/j conversion