### PR TITLE
feat: Expand state interface

### DIFF
--- a/tierkreis/migrations/2026-06-01-094031-0000_create_tables/down.sql
+++ b/tierkreis/migrations/2026-06-01-094031-0000_create_tables/down.sql
@@ -3,3 +3,4 @@ DROP TABLE IF EXISTS `node_states`;
 DROP TABLE IF EXISTS `workflows`;
 DROP TABLE IF EXISTS `node_outputs`;
 DROP TABLE IF EXISTS `workflow_runs`;
+DROP TABLE IF EXISTS `workflow_run_inputs`;

--- a/tierkreis/migrations/2026-06-01-094031-0000_create_tables/up.sql
+++ b/tierkreis/migrations/2026-06-01-094031-0000_create_tables/up.sql
@@ -23,7 +23,8 @@ CREATE TABLE `node_states`(
 CREATE TABLE `workflows`(
 	`id` TEXT NOT NULL PRIMARY KEY,
 	`name` TEXT,
-	`created_time` TIMESTAMP
+	`created_time` TIMESTAMP,
+	`definition` BLOB NOT NULL
 );
 
 CREATE TABLE `node_outputs`(
@@ -49,3 +50,12 @@ CREATE TABLE `workflow_runs`(
 	FOREIGN KEY (`workflow_id`) REFERENCES `workflows`(`id`)
 );
 
+CREATE TABLE `workflow_run_inputs` (
+	`id` INTEGER NOT NULL PRIMARY KEY,
+	`workflow_run_id` TEXT NOT NULL,
+	`name` TEXT NOT NULL,
+	`asset_kind` TEXT NOT NULL,
+	`storage_name` TEXT NOT NULL,
+	`asset_key` TEXT NOT NULL,
+	FOREIGN KEY (`workflow_run_id`) REFERENCES `workflow_runs` (`id`)
+)

--- a/tierkreis/src/runtime.rs
+++ b/tierkreis/src/runtime.rs
@@ -173,7 +173,7 @@ impl<RS: RuntimeState> Runtime<RS> {
         let run_id = Uuid::now_v7();
         let attempt = 0;
 
-        let workflow_run_state = self.state.get_workflow_run_state(run_id, attempt).await?;
+        let workflow_run_state = self.state.load_workflow_run_state(run_id, attempt).await?;
         let workflow_run_state = Arc::new(workflow_run_state);
         let updater = Updater::new(Arc::clone(&workflow_run_state));
 
@@ -233,7 +233,7 @@ impl<RS: RuntimeState> Runtime<RS> {
                 }
                 (updated.run_id, updated.attempt)
             };
-            let workflow_run_state = self.state.get_workflow_run_state(run_id, attempt).await?;
+            let workflow_run_state = self.state.load_workflow_run_state(run_id, attempt).await?;
             let workflow_run_state = Arc::new(workflow_run_state);
 
             // TODO: Handle inputs better here.
@@ -255,7 +255,7 @@ impl<RS: RuntimeState> Runtime<RS> {
         run_id: Uuid,
         attempt: u32,
     ) -> miette::Result<HashMap<String, Vec<u8>>> {
-        let workflow_run_state = self.state.get_workflow_run_state(run_id, attempt).await?;
+        let workflow_run_state = self.state.load_workflow_run_state(run_id, attempt).await?;
 
         let output_state = workflow_run_state
             .read(&Location::from_node_index_iter([self

--- a/tierkreis/src/runtime.rs
+++ b/tierkreis/src/runtime.rs
@@ -173,7 +173,7 @@ impl<RS: RuntimeState> Runtime<RS> {
         let run_id = Uuid::now_v7();
         let attempt = 0;
 
-        let workflow_run_state = self.state.workflow_run_state(run_id, attempt).await?;
+        let workflow_run_state = self.state.get_workflow_run_state(run_id, attempt).await?;
         let workflow_run_state = Arc::new(workflow_run_state);
         let updater = Updater::new(Arc::clone(&workflow_run_state));
 
@@ -233,7 +233,7 @@ impl<RS: RuntimeState> Runtime<RS> {
                 }
                 (updated.run_id, updated.attempt)
             };
-            let workflow_run_state = self.state.workflow_run_state(run_id, attempt).await?;
+            let workflow_run_state = self.state.get_workflow_run_state(run_id, attempt).await?;
             let workflow_run_state = Arc::new(workflow_run_state);
 
             // TODO: Handle inputs better here.
@@ -255,7 +255,7 @@ impl<RS: RuntimeState> Runtime<RS> {
         run_id: Uuid,
         attempt: u32,
     ) -> miette::Result<HashMap<String, Vec<u8>>> {
-        let workflow_run_state = self.state.workflow_run_state(run_id, attempt).await?;
+        let workflow_run_state = self.state.get_workflow_run_state(run_id, attempt).await?;
 
         let output_state = workflow_run_state
             .read(&Location::from_node_index_iter([self

--- a/tierkreis/src/state/inmemory.rs
+++ b/tierkreis/src/state/inmemory.rs
@@ -20,7 +20,9 @@ use tracing::instrument;
 use uuid::Uuid;
 
 use crate::{
+    asset_storage::AssetSpec,
     event::{Event, WorkflowRunEvent},
+    graph::WorkflowGraph,
     state::interface::RunAttemptUpdated,
 };
 use crate::{
@@ -35,6 +37,8 @@ use crate::{
 /// [`RunAttemptState`] is the full state of a run.
 #[derive(Debug, Default)]
 struct RunAttemptState {
+    workflow_id: Uuid,
+    inputs: HashMap<String, AssetSpec>,
     nodes: HashMap<Location, NodeState>,
     metadata: HashMap<String, String>,
 }
@@ -44,6 +48,7 @@ struct RunAttemptState {
 /// references.
 #[derive(Debug, Default)]
 struct InMemoryRuntimeStateInner {
+    workflows: DashMap<Uuid, WorkflowGraph>,
     runs: DashMap<(Uuid, u32), RunAttemptState>,
 }
 
@@ -67,6 +72,7 @@ impl InMemoryRuntimeState {
         });
         Self {
             inner: Arc::new(InMemoryRuntimeStateInner {
+                workflows: DashMap::new(),
                 runs: DashMap::new(),
             }),
 
@@ -85,18 +91,53 @@ impl Default for InMemoryRuntimeState {
 impl RuntimeState for InMemoryRuntimeState {
     type WorkflowRunState = InMemoryWorkflowRunState;
 
-    async fn workflow_run_state(
+    async fn load_workflow(&self, workflow_id: Uuid) -> miette::Result<WorkflowGraph> {
+        let workflow = self
+            .inner
+            .workflows
+            .get(&workflow_id)
+            .ok_or_else(|| miette!("Workflow not found with workflow id: {workflow_id}"))?;
+        Ok(workflow.clone())
+    }
+
+    async fn save_workflow(&self, workflow_graph: WorkflowGraph) -> miette::Result<Uuid> {
+        let workflow_id = Uuid::now_v7();
+        self.inner.workflows.insert(workflow_id, workflow_graph);
+        Ok(workflow_id)
+    }
+
+    async fn new_workflow_run_state(
         &self,
-        run_id: Uuid,
-        attempt: u32,
-    ) -> miette::Result<InMemoryWorkflowRunState> {
-        let entry = self.inner.runs.entry((run_id, attempt));
-        // Insert the default if the value does not yet exist.
-        entry.or_default();
+        workflow_id: Uuid,
+        inputs: HashMap<String, AssetSpec>,
+    ) -> miette::Result<Self::WorkflowRunState> {
+        let run_id = Uuid::now_v7();
+        let attempt = 0;
+
+        let mut entry = self.inner.runs.entry((run_id, attempt)).or_default();
+        entry.workflow_id = workflow_id;
+        entry.inputs = inputs;
 
         Ok(InMemoryWorkflowRunState {
             global_state: Arc::clone(&self.inner),
             update_sender: self.update_sender.clone(),
+            workflow_id: entry.workflow_id,
+            run_id,
+            attempt,
+        })
+    }
+
+    async fn get_workflow_run_state(
+        &self,
+        run_id: Uuid,
+        attempt: u32,
+    ) -> miette::Result<InMemoryWorkflowRunState> {
+        let entry = self.inner.runs.entry((run_id, attempt)).or_default();
+
+        Ok(InMemoryWorkflowRunState {
+            global_state: Arc::clone(&self.inner),
+            update_sender: self.update_sender.clone(),
+            workflow_id: entry.workflow_id,
             run_id,
             attempt,
         })
@@ -124,6 +165,7 @@ impl RuntimeState for InMemoryRuntimeState {
 pub struct InMemoryWorkflowRunState {
     global_state: Arc<InMemoryRuntimeStateInner>,
     update_sender: watch::Sender<RunAttemptUpdated>,
+    workflow_id: Uuid,
     run_id: Uuid,
     attempt: u32,
 }
@@ -148,6 +190,7 @@ impl InMemoryWorkflowRunState {
             Self {
                 global_state: Arc::clone(&global_state.inner),
                 update_sender: global_state.update_sender.clone(),
+                workflow_id: Uuid::nil(),
                 run_id: Uuid::nil(),
                 attempt: 0,
             },
@@ -157,6 +200,27 @@ impl InMemoryWorkflowRunState {
 }
 
 impl WorkflowRunState for InMemoryWorkflowRunState {
+    fn workflow_id(&self) -> Uuid {
+        self.workflow_id
+    }
+
+    fn run_id(&self) -> Uuid {
+        self.run_id
+    }
+
+    fn attempt(&self) -> u32 {
+        self.attempt
+    }
+
+    async fn load_inputs(&self) -> miette::Result<HashMap<String, AssetSpec>> {
+        let run = self
+            .global_state
+            .runs
+            .get(&(self.run_id, self.attempt))
+            .ok_or_else(|| miette!("Workflow run not found"))?;
+        Ok(run.inputs.clone())
+    }
+
     #[instrument]
     async fn write(&self, event: Event) -> miette::Result<()> {
         let global_state = &self.global_state;
@@ -328,7 +392,9 @@ mod tests {
 
         let run_id = Uuid::now_v7();
         let attempt = 0;
-        let workflow_run_state = runtime_state.workflow_run_state(run_id, attempt).await?;
+        let workflow_run_state = runtime_state
+            .get_workflow_run_state(run_id, attempt)
+            .await?;
 
         let node_state = workflow_run_state.read(&Location::root()).await?;
 
@@ -346,7 +412,9 @@ mod tests {
 
         let run_id = Uuid::now_v7();
         let attempt = 0;
-        let workflow_run_state = runtime_state.workflow_run_state(run_id, attempt).await?;
+        let workflow_run_state = runtime_state
+            .get_workflow_run_state(run_id, attempt)
+            .await?;
 
         workflow_run_state
             .write(Event::Node(NodeEvent {
@@ -375,7 +443,9 @@ mod tests {
 
         let run_id = Uuid::now_v7();
         let attempt = 0;
-        let workflow_run_state = runtime_state.workflow_run_state(run_id, attempt).await?;
+        let workflow_run_state = runtime_state
+            .get_workflow_run_state(run_id, attempt)
+            .await?;
 
         workflow_run_state
             .write(Event::Node(NodeEvent {
@@ -398,7 +468,9 @@ mod tests {
 
         let run_id = Uuid::now_v7();
         let attempt = 0;
-        let workflow_run_state = runtime_state.workflow_run_state(run_id, attempt).await?;
+        let workflow_run_state = runtime_state
+            .get_workflow_run_state(run_id, attempt)
+            .await?;
 
         let metadata = HashMap::from_iter([("foo".to_string(), "bar".to_string())]);
         workflow_run_state.add_metadata(metadata.clone()).await?;
@@ -417,7 +489,9 @@ mod tests {
 
         let run_id = Uuid::now_v7();
         let attempt = 0;
-        let workflow_run_state = runtime_state.workflow_run_state(run_id, attempt).await?;
+        let workflow_run_state = runtime_state
+            .get_workflow_run_state(run_id, attempt)
+            .await?;
 
         let mut metadata1 = HashMap::from_iter([("foo".to_string(), "bar".to_string())]);
         workflow_run_state.add_metadata(metadata1.clone()).await?;

--- a/tierkreis/src/state/inmemory.rs
+++ b/tierkreis/src/state/inmemory.rs
@@ -127,7 +127,7 @@ impl RuntimeState for InMemoryRuntimeState {
         })
     }
 
-    async fn get_workflow_run_state(
+    async fn load_workflow_run_state(
         &self,
         run_id: Uuid,
         attempt: u32,
@@ -393,7 +393,7 @@ mod tests {
         let run_id = Uuid::now_v7();
         let attempt = 0;
         let workflow_run_state = runtime_state
-            .get_workflow_run_state(run_id, attempt)
+            .load_workflow_run_state(run_id, attempt)
             .await?;
 
         let node_state = workflow_run_state.read(&Location::root()).await?;
@@ -413,7 +413,7 @@ mod tests {
         let run_id = Uuid::now_v7();
         let attempt = 0;
         let workflow_run_state = runtime_state
-            .get_workflow_run_state(run_id, attempt)
+            .load_workflow_run_state(run_id, attempt)
             .await?;
 
         workflow_run_state
@@ -444,7 +444,7 @@ mod tests {
         let run_id = Uuid::now_v7();
         let attempt = 0;
         let workflow_run_state = runtime_state
-            .get_workflow_run_state(run_id, attempt)
+            .load_workflow_run_state(run_id, attempt)
             .await?;
 
         workflow_run_state
@@ -469,7 +469,7 @@ mod tests {
         let run_id = Uuid::now_v7();
         let attempt = 0;
         let workflow_run_state = runtime_state
-            .get_workflow_run_state(run_id, attempt)
+            .load_workflow_run_state(run_id, attempt)
             .await?;
 
         let metadata = HashMap::from_iter([("foo".to_string(), "bar".to_string())]);
@@ -490,7 +490,7 @@ mod tests {
         let run_id = Uuid::now_v7();
         let attempt = 0;
         let workflow_run_state = runtime_state
-            .get_workflow_run_state(run_id, attempt)
+            .load_workflow_run_state(run_id, attempt)
             .await?;
 
         let mut metadata1 = HashMap::from_iter([("foo".to_string(), "bar".to_string())]);

--- a/tierkreis/src/state/interface.rs
+++ b/tierkreis/src/state/interface.rs
@@ -9,7 +9,7 @@ use chrono::{DateTime, Utc};
 use tokio::sync::watch;
 use uuid::Uuid;
 
-use crate::{asset_storage::AssetSpec, event::Event, location::Location};
+use crate::{asset_storage::AssetSpec, event::Event, graph::WorkflowGraph, location::Location};
 
 /// [`RunAttemptUpdated`] is a struct that is emitted by the [`RuntimeState`] interface
 /// whenever a run attempt changes, in order to drive further workflow orchestration.
@@ -67,10 +67,28 @@ pub trait RuntimeState: Debug + Send + Sync {
     /// [`WorkflowRunState`] is the implementation of the [`WorkflowRunState`] trait that is associated
     /// with this [`RuntimeState`] implementation and returned by the `workflow_run_state` method.
     type WorkflowRunState: WorkflowRunState;
+
+    /// Retrieve the [`WorkflowGraph`] specified by id.
+    fn load_workflow(
+        &self,
+        workflow_id: Uuid,
+    ) -> impl Future<Output = miette::Result<WorkflowGraph>> + Send;
+    /// Save a [`WorkflowGraph`] and return a new id.
+    fn save_workflow(
+        &self,
+        workflow_graph: WorkflowGraph,
+    ) -> impl Future<Output = miette::Result<Uuid>> + Send;
+
+    /// Create a new [`WorkflowRunState`] for a Workflow in the [`RuntimeState`] specified by id.
+    fn new_workflow_run_state(
+        &self,
+        workflow_id: Uuid,
+        inputs: HashMap<String, AssetSpec>,
+    ) -> impl Future<Output = miette::Result<Self::WorkflowRunState>> + Send;
     /// Retrieve a handle to a [`WorkflowRunState`] depending on the `run_id` and attempt number.
     ///
     /// If the backing data for the [`WorkflowRunState`] does not exist, create it.
-    fn workflow_run_state(
+    fn get_workflow_run_state(
         &self,
         run_id: Uuid,
         attempt: u32,
@@ -85,7 +103,17 @@ pub trait RuntimeState: Debug + Send + Sync {
 
 /// [`WorkflowRunState`] is an interface to the state of an individual Workflow run attempt.
 pub trait WorkflowRunState: Debug + Send + Sync {
-    /// Update the [`WorkflowRunState`] from an [`Event`].
+    /// Retrieve the id for the [`WorkflowGraph`] associated with this Workflow run attempt.
+    fn workflow_id(&self) -> Uuid;
+    /// Retrieve the `run_id` associated with this `WorkflowRunState`.
+    fn run_id(&self) -> Uuid;
+    /// Retrieve the `attempt` associated with this `WorkflowRunState`.
+    fn attempt(&self) -> u32;
+    /// Retrieve the workflow inputs associated with this `WorkflowRunState`.
+    fn load_inputs(
+        &self,
+    ) -> impl Future<Output = miette::Result<HashMap<String, AssetSpec>>> + Send;
+    /// Update the [`WorkflowRunState`] from a [`WorkflowRunEvent`].
     fn write(&self, event: Event) -> impl Future<Output = miette::Result<()>> + Send;
     /// Read the state of a Node at the specified [`Location`].
     ///

--- a/tierkreis/src/state/interface.rs
+++ b/tierkreis/src/state/interface.rs
@@ -88,7 +88,7 @@ pub trait RuntimeState: Debug + Send + Sync {
     /// Retrieve a handle to a [`WorkflowRunState`] depending on the `run_id` and attempt number.
     ///
     /// If the backing data for the [`WorkflowRunState`] does not exist, create it.
-    fn get_workflow_run_state(
+    fn load_workflow_run_state(
         &self,
         run_id: Uuid,
         attempt: u32,

--- a/tierkreis/src/state/models.rs
+++ b/tierkreis/src/state/models.rs
@@ -1,6 +1,8 @@
 #![allow(missing_docs)]
 use crate::location::Location;
-use crate::state::schema::{node_outputs, node_states, workflow_runs, workflows};
+use crate::state::schema::{
+    node_outputs, node_states, workflow_run_inputs, workflow_runs, workflows,
+};
 use chrono::NaiveDateTime;
 use diesel::prelude::*;
 
@@ -13,6 +15,7 @@ use diesel::prelude::*;
 pub struct Workflow {
     pub id: String, // UUID string
     pub name: Option<String>,
+    pub definition: Vec<u8>, // JSON blob
     pub created_time: Option<NaiveDateTime>,
 }
 
@@ -82,6 +85,32 @@ pub struct UpsertNodeState {
 }
 
 // -----------------------------------------------------------------------------
+// Workflow Run Inputs
+// -----------------------------------------------------------------------------
+
+#[derive(Queryable, Selectable, Identifiable, Associations, Debug, Clone)]
+#[diesel(belongs_to(WorkflowRun, foreign_key = workflow_run_id))]
+#[diesel(table_name = workflow_run_inputs)]
+pub struct WorkflowRunInput {
+    pub id: i32,
+    pub workflow_run_id: String,
+    pub name: String,
+    pub asset_kind: String,
+    pub storage_name: String,
+    pub asset_key: String,
+}
+
+#[derive(Insertable, Debug, Clone)]
+#[diesel(table_name = workflow_run_inputs)]
+pub struct NewWorkflowRunInput<'a> {
+    pub workflow_run_id: &'a str,
+    pub name: &'a str,
+    pub asset_kind: String,
+    pub storage_name: &'a str,
+    pub asset_key: String,
+}
+
+// -----------------------------------------------------------------------------
 // Node Outputs
 // -----------------------------------------------------------------------------
 
@@ -99,9 +128,9 @@ pub struct NodeOutput {
 
 #[derive(Insertable, Debug, Clone)]
 #[diesel(table_name = node_outputs)]
-pub struct NewNodeOutput {
-    pub name: String,
+pub struct NewNodeOutput<'a> {
+    pub name: &'a str,
     pub asset_kind: String,
-    pub storage_name: String,
+    pub storage_name: &'a str,
     pub asset_key: String,
 }

--- a/tierkreis/src/state/queries.rs
+++ b/tierkreis/src/state/queries.rs
@@ -20,11 +20,57 @@ use miette::{IntoDiagnostic, WrapErr, miette};
 use crate::asset_storage::AssetSpec;
 use crate::location::Location;
 use crate::state::models::{
-    NewNodeOutput, NodeOutput, NodeState, UpsertNodeState, Workflow, WorkflowRun,
+    NewNodeOutput, NewWorkflowRunInput, NodeOutput, NodeState, UpsertNodeState, Workflow,
+    WorkflowRun, WorkflowRunInput,
 };
 
 fn utc_timestamp(ts: NaiveDateTime) -> DateTime<Utc> {
     DateTime::<Utc>::from_naive_utc_and_offset(ts, Utc)
+}
+
+/// Insert a workflow run row.
+///
+/// # Errors
+///
+/// Returns an error when the insert fails.
+pub async fn read_workflow(
+    conn: &mut impl AsyncConnection<Backend = Sqlite>,
+    workflow_id: uuid::Uuid,
+) -> miette::Result<Workflow> {
+    use crate::state::schema::workflows::dsl as wf;
+
+    let workflow = wf::workflows
+        .find(workflow_id.to_string())
+        .select(Workflow::as_select())
+        .get_result(conn)
+        .await
+        .into_diagnostic()
+        .wrap_err_with(|| miette!("Failed to select workflow with id: {}", workflow_id))?;
+
+    Ok(workflow)
+}
+
+/// Insert a workflow run row.
+///
+/// # Errors
+///
+/// Returns an error when the insert fails.
+pub async fn insert_workflow(
+    conn: &mut impl AsyncConnection<Backend = Sqlite>,
+    workflow: &Workflow,
+) -> miette::Result<()> {
+    use crate::state::schema::workflows::dsl as wf;
+
+    diesel::insert_into(wf::workflows)
+        .values(workflow)
+        .on_conflict(wf::id)
+        .do_nothing()
+        .execute(conn)
+        .await
+        .into_diagnostic()
+        .wrap_err_with(|| miette!("Failed to insert workflow with id: {}", workflow.id,))?;
+
+    Ok(())
 }
 
 /// Load the run-attempt state for a workflow run if it exists.
@@ -109,6 +155,7 @@ pub async fn insert_default_workflowrun(
         id: workflow_id.clone(),
         name: None,
         created_time: Some(Utc::now().naive_utc()),
+        definition: Vec::new(),
     };
 
     diesel::insert_or_ignore_into(wf::workflows)
@@ -182,7 +229,7 @@ pub async fn update_node_state(
     run_id: &str,
     attempt: i32,
     mut node_updates: Vec<UpsertNodeState>,
-    node_outputs: Vec<(Location, NewNodeOutput)>,
+    node_outputs: Vec<(Location, NewNodeOutput<'_>)>,
 ) -> miette::Result<bool> {
     use crate::state::schema::node_states::dsl as ns;
 
@@ -239,7 +286,7 @@ pub async fn update_node_state(
                     .await?;
             }
 
-            save_outputs(conn, run_id, attempt, node_outputs).await?;
+            insert_outputs(conn, run_id, attempt, node_outputs).await?;
 
             Ok::<_, diesel::result::Error>(rows_affected > 0)
         }
@@ -247,50 +294,6 @@ pub async fn update_node_state(
     })
     .await
     .into_diagnostic()
-}
-
-async fn save_outputs(
-    conn: &mut impl AsyncConnection<Backend = Sqlite>,
-    run_id: &str,
-    attempt: i32,
-    node_outputs: Vec<(Location, NewNodeOutput)>,
-) -> Result<(), diesel::result::Error> {
-    use crate::state::schema::node_outputs::dsl as no;
-    use crate::state::schema::node_states::dsl as ns;
-
-    if !node_outputs.is_empty() {
-        let locations = node_outputs.iter().map(|(x, _)| x);
-        let node_state_ids: HashMap<Location, i32> = ns::node_states
-            .select((ns::node_location, ns::id))
-            .filter(ns::run_id.eq(run_id))
-            .filter(ns::attempt.eq(attempt))
-            .filter(ns::node_location.eq_any(locations))
-            .get_results(conn)
-            .await?
-            .into_iter()
-            .collect();
-
-        let db_outputs: Vec<_> = node_outputs
-            .into_iter()
-            .map(|(location, node_output)| {
-                (
-                    no::node_state_id.eq(node_state_ids.get(&location).unwrap()),
-                    node_output,
-                )
-            })
-            .collect();
-
-        // TODO: We shouldn't need to loop if batch inserts for sqlite and diesel_async are patched.
-        for db_output in db_outputs {
-            diesel::insert_into(no::node_outputs)
-                .values(db_output)
-                .on_conflict((no::node_state_id, no::name)) // TODO: Might need a unique index?
-                .do_nothing()
-                .execute(conn)
-                .await?;
-        }
-    }
-    Ok(())
 }
 
 async fn merge_map_complete_fields(
@@ -417,6 +420,108 @@ pub async fn read_node_state(
     } else {
         Ok(crate::state::interface::NodeState::default())
     }
+}
+
+/// Insert persisted workflow inputs for a workflow run.
+///
+/// # Errors
+///
+/// Returns an error when the connection pool cannot be accessed or the workflow run
+/// input inserts fail.
+pub async fn insert_workflow_run_inputs(
+    conn: &mut impl AsyncConnection<Backend = Sqlite>,
+    workflow_inputs: impl Iterator<Item = NewWorkflowRunInput<'_>>,
+) -> miette::Result<()> {
+    use crate::state::schema::workflow_run_inputs::dsl as wri;
+
+    for workflow_input in workflow_inputs {
+        diesel::insert_into(wri::workflow_run_inputs)
+            .values(workflow_input)
+            .execute(conn)
+            .await
+            .into_diagnostic()?;
+    }
+
+    Ok(())
+}
+
+/// Read the persisted workflow inputs for a workflow run.
+///
+/// # Errors
+///
+/// Returns an error when the connection pool cannot be accessed or the workflow run
+/// inputs lookup fails.
+pub async fn read_workflow_run_inputs(
+    conn: &mut impl AsyncConnection<Backend = Sqlite>,
+    workflow_run_id: &str,
+) -> miette::Result<HashMap<String, AssetSpec>> {
+    use crate::state::schema::workflow_run_inputs::dsl as wri;
+
+    let inputs = wri::workflow_run_inputs
+        .select(WorkflowRunInput::as_select())
+        .filter(wri::workflow_run_id.eq(workflow_run_id))
+        .get_results(conn)
+        .await
+        .into_diagnostic()?;
+
+    let inputs = inputs
+        .into_iter()
+        .map(|input| {
+            let asset = AssetSpec {
+                asset_key: input.asset_key.parse().into_diagnostic()?,
+                kind: input.asset_kind.parse()?,
+                storage_name: input.storage_name,
+            };
+
+            Ok((input.name, asset))
+        })
+        .collect::<miette::Result<HashMap<_, _>>>()?;
+
+    Ok(inputs)
+}
+
+async fn insert_outputs(
+    conn: &mut impl AsyncConnection<Backend = Sqlite>,
+    run_id: &str,
+    attempt: i32,
+    node_outputs: Vec<(Location, NewNodeOutput<'_>)>,
+) -> Result<(), diesel::result::Error> {
+    use crate::state::schema::node_outputs::dsl as no;
+    use crate::state::schema::node_states::dsl as ns;
+
+    if !node_outputs.is_empty() {
+        let locations = node_outputs.iter().map(|(x, _)| x);
+        let node_state_ids: HashMap<Location, i32> = ns::node_states
+            .select((ns::node_location, ns::id))
+            .filter(ns::run_id.eq(run_id))
+            .filter(ns::attempt.eq(attempt))
+            .filter(ns::node_location.eq_any(locations))
+            .get_results(conn)
+            .await?
+            .into_iter()
+            .collect();
+
+        let db_outputs: Vec<_> = node_outputs
+            .into_iter()
+            .map(|(location, node_output)| {
+                (
+                    no::node_state_id.eq(node_state_ids.get(&location).unwrap()),
+                    node_output,
+                )
+            })
+            .collect();
+
+        // TODO: We shouldn't need to loop if batch inserts for sqlite and diesel_async are patched.
+        for db_output in db_outputs {
+            diesel::insert_into(no::node_outputs)
+                .values(db_output)
+                .on_conflict((no::node_state_id, no::name)) // TODO: Might need a unique index?
+                .do_nothing()
+                .execute(conn)
+                .await?;
+        }
+    }
+    Ok(())
 }
 
 async fn read_outputs(

--- a/tierkreis/src/state/queries.rs
+++ b/tierkreis/src/state/queries.rs
@@ -28,7 +28,7 @@ fn utc_timestamp(ts: NaiveDateTime) -> DateTime<Utc> {
     DateTime::<Utc>::from_naive_utc_and_offset(ts, Utc)
 }
 
-/// Insert a workflow run row.
+/// Read a workflow graph from the workflows table.
 ///
 /// # Errors
 ///
@@ -50,7 +50,7 @@ pub async fn read_workflow(
     Ok(workflow)
 }
 
-/// Insert a workflow run row.
+/// Insert a workflow graph to the workflows table.
 ///
 /// # Errors
 ///

--- a/tierkreis/src/state/schema.rs
+++ b/tierkreis/src/state/schema.rs
@@ -33,6 +33,17 @@ diesel::table! {
 }
 
 diesel::table! {
+    workflow_run_inputs (id) {
+        id -> Integer,
+        workflow_run_id -> Text,
+        name -> Text,
+        asset_kind -> Text,
+        storage_name -> Text,
+        asset_key -> Text,
+    }
+}
+
+diesel::table! {
     workflow_runs (id, attempt) {
         id -> Text,
         attempt -> Integer,
@@ -48,10 +59,17 @@ diesel::table! {
         id -> Text,
         name -> Nullable<Text>,
         created_time -> Nullable<Timestamp>,
+        definition -> Binary,
     }
 }
 
 diesel::joinable!(node_outputs -> node_states (node_state_id));
 diesel::joinable!(workflow_runs -> workflows (workflow_id));
 
-diesel::allow_tables_to_appear_in_same_query!(node_outputs, node_states, workflow_runs, workflows,);
+diesel::allow_tables_to_appear_in_same_query!(
+    node_outputs,
+    node_states,
+    workflow_run_inputs,
+    workflow_runs,
+    workflows,
+);

--- a/tierkreis/src/state/sql.rs
+++ b/tierkreis/src/state/sql.rs
@@ -216,8 +216,8 @@ impl RuntimeState for SqliteRuntimeState {
     type WorkflowRunState = SqliteWorkflowRunState;
 
     async fn load_workflow(&self, workflow_id: Uuid) -> miette::Result<WorkflowGraph> {
-        let mut conn = self.get_conn().await?;
         let _lock = self.lock.read().await;
+        let mut conn = self.get_conn().await?;
         let workflow = read_workflow(&mut conn, workflow_id).await?;
         serde_json::from_slice(&workflow.definition).into_diagnostic()
     }
@@ -230,8 +230,8 @@ impl RuntimeState for SqliteRuntimeState {
             created_time: Some(Utc::now().naive_utc()),
             definition: serde_json::to_vec(&workflow_graph).into_diagnostic()?,
         };
-        let mut conn = self.get_conn().await?;
         let _lock = self.lock.write().await;
+        let mut conn = self.get_conn().await?;
         insert_workflow(&mut conn, &workflow).await?;
         Ok(id)
     }
@@ -241,8 +241,8 @@ impl RuntimeState for SqliteRuntimeState {
         workflow_id: Uuid,
         inputs: HashMap<String, crate::asset_storage::AssetSpec>,
     ) -> miette::Result<Self::WorkflowRunState> {
-        let mut conn = self.get_conn().await?;
         let _lock = self.lock.write().await;
+        let mut conn = self.get_conn().await?;
         let run_id = Uuid::now_v7();
         let run_id_str = run_id.to_string();
         let attempt = 0;
@@ -360,19 +360,14 @@ impl WorkflowRunState for SqliteWorkflowRunState {
     }
 
     async fn load_inputs(&self) -> miette::Result<HashMap<String, AssetSpec>> {
-        let mut conn = self
-            .pool
-            .get()
-            .await
-            .into_diagnostic()
-            .wrap_err("Error acquiring connection from pool")?;
         let _lock = self.lock.read().await;
+        let mut conn = self.get_conn().await?;
         read_workflow_run_inputs(&mut conn, &self.run_id.to_string()).await
     }
 
     async fn write(&self, event: Event) -> miette::Result<()> {
-        let mut send_workflow_stopped = false;
         let _lock = self.lock.write().await;
+        let mut send_workflow_stopped = false;
 
         match event {
             Event::WorkflowRun(ref run_event) => {
@@ -390,40 +385,38 @@ impl WorkflowRunState for SqliteWorkflowRunState {
     }
 
     async fn read(&self, location: &Location) -> miette::Result<NodeState> {
-        let mut conn = self
-            .pool
-            .get()
-            .await
-            .into_diagnostic()
-            .wrap_err("Error acquiring connection from pool")?;
         let _lock = self.lock.read().await;
+        let mut conn = self.get_conn().await?;
         read_node_state(&mut conn, self.run_id, self.attempt, location).await
     }
 
     async fn add_metadata(&self, metadata: HashMap<String, String>) -> miette::Result<()> {
-        let mut conn = self
-            .pool
-            .get()
-            .await
-            .into_diagnostic()
-            .wrap_err("Error acquiring connection from pool")?;
         let _lock = self.lock.write().await;
+        let mut conn = self.get_conn().await?;
         add_run_metadata(&mut conn, self.run_id, self.attempt, metadata).await
     }
 
     async fn read_metadata(&self) -> miette::Result<HashMap<String, String>> {
-        let mut conn = self
-            .pool
-            .get()
-            .await
-            .into_diagnostic()
-            .wrap_err("Error acquiring connection from pool")?;
         let _lock = self.lock.read().await;
+        let mut conn = self.get_conn().await?;
         read_run_metadata(&mut conn, self.run_id, self.attempt).await
     }
 }
 
 impl SqliteWorkflowRunState {
+    async fn get_conn(
+        &self,
+    ) -> miette::Result<Object<AsyncDieselConnectionManager<SyncConnectionWrapper<SqliteConnection>>>>
+    {
+        let conn = self
+            .pool
+            .get()
+            .await
+            .into_diagnostic()
+            .wrap_err("Error acquiring connection from pool")?;
+        Ok(conn)
+    }
+
     fn handle_run_event(send_workflow_stopped: &mut bool, run_event: &WorkflowRunEvent) {
         match run_event {
             WorkflowRunEvent::Started {} => {}

--- a/tierkreis/src/state/sql.rs
+++ b/tierkreis/src/state/sql.rs
@@ -276,7 +276,7 @@ impl RuntimeState for SqliteRuntimeState {
         })
     }
 
-    async fn get_workflow_run_state(
+    async fn load_workflow_run_state(
         &self,
         run_id: Uuid,
         attempt: u32,
@@ -551,7 +551,7 @@ mod tests {
         let run_id = Uuid::now_v7();
         let attempt = 0;
         let workflow_run_state = runtime_state
-            .get_workflow_run_state(run_id, attempt)
+            .load_workflow_run_state(run_id, attempt)
             .await?;
 
         let node_state = workflow_run_state.read(&Location::root()).await?;
@@ -571,7 +571,7 @@ mod tests {
         let run_id = Uuid::now_v7();
         let attempt = 1;
         let workflow_run_state = runtime_state
-            .get_workflow_run_state(run_id, attempt)
+            .load_workflow_run_state(run_id, attempt)
             .await?;
 
         workflow_run_state
@@ -602,7 +602,7 @@ mod tests {
         let run_id = Uuid::now_v7();
         let attempt = 2;
         let workflow_run_state = runtime_state
-            .get_workflow_run_state(run_id, attempt)
+            .load_workflow_run_state(run_id, attempt)
             .await?;
 
         workflow_run_state
@@ -639,7 +639,7 @@ mod tests {
         let run_id = Uuid::now_v7();
         let attempt = 2;
         let workflow_run_state = runtime_state
-            .get_workflow_run_state(run_id, attempt)
+            .load_workflow_run_state(run_id, attempt)
             .await?;
 
         let mut outputs = HashMap::new();
@@ -675,7 +675,7 @@ mod tests {
         let run_id = Uuid::now_v7();
         let attempt = 2;
         let workflow_run_state = runtime_state
-            .get_workflow_run_state(run_id, attempt)
+            .load_workflow_run_state(run_id, attempt)
             .await?;
 
         workflow_run_state
@@ -736,7 +736,7 @@ mod tests {
         let run_id = Uuid::now_v7();
         let attempt = 3;
         let workflow_run_state = runtime_state
-            .get_workflow_run_state(run_id, attempt)
+            .load_workflow_run_state(run_id, attempt)
             .await?;
 
         let metadata = HashMap::from_iter([("foo".to_string(), "bar".to_string())]);
@@ -756,7 +756,7 @@ mod tests {
         let run_id = Uuid::now_v7();
         let attempt = 4;
         let workflow_run_state = runtime_state
-            .get_workflow_run_state(run_id, attempt)
+            .load_workflow_run_state(run_id, attempt)
             .await?;
 
         let mut metadata1 = HashMap::from_iter([("foo".to_string(), "bar".to_string())]);

--- a/tierkreis/src/state/sql.rs
+++ b/tierkreis/src/state/sql.rs
@@ -15,11 +15,10 @@ use std::{
 
 use bitvec::vec::BitVec;
 use chrono::Utc;
-use deadpool::Runtime;
+use deadpool::{Runtime, managed::Object};
 use diesel::SqliteConnection;
 use diesel_async::{
-    AsyncMigrationHarness,
-    pooled_connection::{AsyncDieselConnectionManager, deadpool::Object},
+    AsyncMigrationHarness, pooled_connection::AsyncDieselConnectionManager,
     sync_connection_wrapper::SyncConnectionWrapper,
 };
 use diesel_migrations::{EmbeddedMigrations, MigrationHarness, embed_migrations};
@@ -28,7 +27,21 @@ use tokio::sync::{RwLock, watch};
 use uuid::Uuid;
 
 use crate::{
-    event::{Event, NodeStatus, RunningStateUpdate},
+    asset_storage::AssetSpec,
+    event::{Event, NodeEvent, WorkflowRunEvent},
+    graph::WorkflowGraph,
+    state::{
+        interface::RunAttemptUpdated,
+        models::{NewWorkflowRunInput, Workflow, WorkflowRun},
+        queries::{
+            add_run_metadata, insert_default_workflowrun, insert_workflow, insert_workflow_run,
+            insert_workflow_run_inputs, read_node_state, read_run_metadata, read_workflow,
+            read_workflow_run_inputs, read_workflowrun, update_node_state,
+        },
+    },
+};
+use crate::{
+    event::{NodeStatus, RunningStateUpdate},
     location::Location,
     state::{
         WorkflowRunState,
@@ -36,21 +49,15 @@ use crate::{
         models::{NewNodeOutput, UpsertNodeState},
     },
 };
-use crate::{
-    event::{NodeEvent, WorkflowRunEvent},
-    state::{
-        interface::RunAttemptUpdated,
-        queries::{
-            add_run_metadata, insert_default_workflowrun, read_node_state, read_run_metadata,
-            read_workflowrun, update_node_state,
-        },
-    },
-};
 
 /// Embedded Diesel migrations
 pub const MIGRATIONS: EmbeddedMigrations = embed_migrations!("migrations");
 
-fn run_migrations(conn: Object<SyncConnectionWrapper<SqliteConnection>>) -> miette::Result<()> {
+fn run_migrations(
+    conn: diesel_async::pooled_connection::deadpool::Object<
+        SyncConnectionWrapper<SqliteConnection>,
+    >,
+) -> miette::Result<()> {
     let mut harness = AsyncMigrationHarness::new(conn);
     harness
         .run_pending_migrations(MIGRATIONS)
@@ -184,6 +191,19 @@ impl SqliteRuntimeState {
             update_receiver: Mutex::new(Some(receiver)),
         })
     }
+
+    async fn get_conn(
+        &self,
+    ) -> miette::Result<Object<AsyncDieselConnectionManager<SyncConnectionWrapper<SqliteConnection>>>>
+    {
+        let conn = self
+            .pool
+            .get()
+            .await
+            .into_diagnostic()
+            .wrap_err("Error acquiring connection from pool")?;
+        Ok(conn)
+    }
 }
 
 impl Debug for SqliteRuntimeState {
@@ -195,33 +215,93 @@ impl Debug for SqliteRuntimeState {
 impl RuntimeState for SqliteRuntimeState {
     type WorkflowRunState = SqliteWorkflowRunState;
 
-    async fn workflow_run_state(
+    async fn load_workflow(&self, workflow_id: Uuid) -> miette::Result<WorkflowGraph> {
+        let mut conn = self.get_conn().await?;
+        let _lock = self.lock.read().await;
+        let workflow = read_workflow(&mut conn, workflow_id).await?;
+        serde_json::from_slice(&workflow.definition).into_diagnostic()
+    }
+
+    async fn save_workflow(&self, workflow_graph: WorkflowGraph) -> miette::Result<Uuid> {
+        let id = Uuid::now_v7();
+        let workflow = Workflow {
+            id: id.to_string(),
+            name: None,
+            created_time: Some(Utc::now().naive_utc()),
+            definition: serde_json::to_vec(&workflow_graph).into_diagnostic()?,
+        };
+        let mut conn = self.get_conn().await?;
+        let _lock = self.lock.write().await;
+        insert_workflow(&mut conn, &workflow).await?;
+        Ok(id)
+    }
+
+    async fn new_workflow_run_state(
+        &self,
+        workflow_id: Uuid,
+        inputs: HashMap<String, crate::asset_storage::AssetSpec>,
+    ) -> miette::Result<Self::WorkflowRunState> {
+        let mut conn = self.get_conn().await?;
+        let _lock = self.lock.write().await;
+        let run_id = Uuid::now_v7();
+        let run_id_str = run_id.to_string();
+        let attempt = 0;
+        let run = WorkflowRun {
+            id: run_id_str.clone(),
+            attempt,
+            workflow_id: workflow_id.to_string(),
+            run_metadata: br"{}".to_vec(),
+            status: None,
+            started_time: None,
+        };
+        insert_workflow_run(&mut conn, &run).await?;
+
+        let workflow_inputs = inputs.iter().map(|(name, asset)| NewWorkflowRunInput {
+            workflow_run_id: &run_id_str,
+            name,
+            asset_kind: asset.kind.to_string(),
+            storage_name: &asset.storage_name,
+            asset_key: asset.asset_key.to_string(),
+        });
+
+        insert_workflow_run_inputs(&mut conn, workflow_inputs).await?;
+
+        Ok(SqliteWorkflowRunState {
+            pool: self.pool.clone(),
+            lock: self.lock.clone(),
+            update_sender: self.update_sender.clone(),
+            workflow_id,
+            run_id,
+            attempt: 0,
+        })
+    }
+
+    async fn get_workflow_run_state(
         &self,
         run_id: Uuid,
         attempt: u32,
     ) -> miette::Result<SqliteWorkflowRunState> {
-        let mut conn = self
-            .pool
-            .get()
-            .await
-            .into_diagnostic()
-            .wrap_err("Error acquiring connection from pool")?;
+        let mut conn = self.get_conn().await?;
         // Insert the default if the value does not yet exist.
         // Cannot return errors from this trait method, so best-effort initialize.
         let run = {
             let _lock = self.lock.read().await;
             read_workflowrun(&mut conn, run_id, attempt).await
         };
-        // Should fail?
-        if run.is_err() {
-            let _lock = self.lock.write().await;
-            _ = insert_default_workflowrun(&mut conn, run_id, attempt).await?;
-        }
+        let workflow_id = match run {
+            Ok(run) => run.workflow_id.parse().into_diagnostic()?,
+            Err(_err) => {
+                let _lock = self.lock.write().await;
+                let run = insert_default_workflowrun(&mut conn, run_id, attempt).await?;
+                run.workflow_id.parse().into_diagnostic()?
+            }
+        };
 
         Ok(SqliteWorkflowRunState {
             pool: self.pool.clone(),
             lock: self.lock.clone(),
             update_sender: self.update_sender.clone(),
+            workflow_id,
             run_id,
             attempt,
         })
@@ -251,6 +331,7 @@ pub struct SqliteWorkflowRunState {
     // control access to the ConnPool.
     lock: Arc<RwLock<()>>,
     update_sender: watch::Sender<RunAttemptUpdated>,
+    workflow_id: Uuid,
     run_id: Uuid,
     attempt: u32,
 }
@@ -266,6 +347,29 @@ impl Debug for SqliteWorkflowRunState {
 }
 
 impl WorkflowRunState for SqliteWorkflowRunState {
+    fn workflow_id(&self) -> Uuid {
+        self.workflow_id
+    }
+
+    fn run_id(&self) -> Uuid {
+        self.run_id
+    }
+
+    fn attempt(&self) -> u32 {
+        self.attempt
+    }
+
+    async fn load_inputs(&self) -> miette::Result<HashMap<String, AssetSpec>> {
+        let mut conn = self
+            .pool
+            .get()
+            .await
+            .into_diagnostic()
+            .wrap_err("Error acquiring connection from pool")?;
+        let _lock = self.lock.read().await;
+        read_workflow_run_inputs(&mut conn, &self.run_id.to_string()).await
+    }
+
     async fn write(&self, event: Event) -> miette::Result<()> {
         let mut send_workflow_stopped = false;
         let _lock = self.lock.write().await;
@@ -286,35 +390,35 @@ impl WorkflowRunState for SqliteWorkflowRunState {
     }
 
     async fn read(&self, location: &Location) -> miette::Result<NodeState> {
-        let _lock = self.lock.read().await;
         let mut conn = self
             .pool
             .get()
             .await
             .into_diagnostic()
             .wrap_err("Error acquiring connection from pool")?;
+        let _lock = self.lock.read().await;
         read_node_state(&mut conn, self.run_id, self.attempt, location).await
     }
 
     async fn add_metadata(&self, metadata: HashMap<String, String>) -> miette::Result<()> {
-        let _lock = self.lock.write().await;
         let mut conn = self
             .pool
             .get()
             .await
             .into_diagnostic()
             .wrap_err("Error acquiring connection from pool")?;
+        let _lock = self.lock.write().await;
         add_run_metadata(&mut conn, self.run_id, self.attempt, metadata).await
     }
 
     async fn read_metadata(&self) -> miette::Result<HashMap<String, String>> {
-        let _lock = self.lock.read().await;
         let mut conn = self
             .pool
             .get()
             .await
             .into_diagnostic()
             .wrap_err("Error acquiring connection from pool")?;
+        let _lock = self.lock.read().await;
         read_run_metadata(&mut conn, self.run_id, self.attempt).await
     }
 }
@@ -390,9 +494,9 @@ impl SqliteWorkflowRunState {
                                 node_outputs.push((
                                     loc.clone(),
                                     NewNodeOutput {
-                                        name: port.clone(),
+                                        name: port,
                                         asset_kind: asset_spec.kind.to_string(),
-                                        storage_name: asset_spec.storage_name.clone(),
+                                        storage_name: &asset_spec.storage_name,
                                         asset_key: asset_spec.asset_key.to_string(),
                                     },
                                 ));
@@ -437,7 +541,6 @@ impl SqliteWorkflowRunState {
 
 #[cfg(test)]
 mod tests {
-
     use std::ops::BitOr;
 
     use crate::{
@@ -454,7 +557,9 @@ mod tests {
 
         let run_id = Uuid::now_v7();
         let attempt = 0;
-        let workflow_run_state = runtime_state.workflow_run_state(run_id, attempt).await?;
+        let workflow_run_state = runtime_state
+            .get_workflow_run_state(run_id, attempt)
+            .await?;
 
         let node_state = workflow_run_state.read(&Location::root()).await?;
 
@@ -472,7 +577,9 @@ mod tests {
 
         let run_id = Uuid::now_v7();
         let attempt = 1;
-        let workflow_run_state = runtime_state.workflow_run_state(run_id, attempt).await?;
+        let workflow_run_state = runtime_state
+            .get_workflow_run_state(run_id, attempt)
+            .await?;
 
         workflow_run_state
             .write(Event::Node(NodeEvent {
@@ -501,7 +608,9 @@ mod tests {
 
         let run_id = Uuid::now_v7();
         let attempt = 2;
-        let workflow_run_state = runtime_state.workflow_run_state(run_id, attempt).await?;
+        let workflow_run_state = runtime_state
+            .get_workflow_run_state(run_id, attempt)
+            .await?;
 
         workflow_run_state
             .write(Event::Node(NodeEvent {
@@ -536,7 +645,9 @@ mod tests {
 
         let run_id = Uuid::now_v7();
         let attempt = 2;
-        let workflow_run_state = runtime_state.workflow_run_state(run_id, attempt).await?;
+        let workflow_run_state = runtime_state
+            .get_workflow_run_state(run_id, attempt)
+            .await?;
 
         let mut outputs = HashMap::new();
         outputs.insert(
@@ -570,7 +681,9 @@ mod tests {
 
         let run_id = Uuid::now_v7();
         let attempt = 2;
-        let workflow_run_state = runtime_state.workflow_run_state(run_id, attempt).await?;
+        let workflow_run_state = runtime_state
+            .get_workflow_run_state(run_id, attempt)
+            .await?;
 
         workflow_run_state
             .write(Event::Node(NodeEvent {
@@ -629,7 +742,9 @@ mod tests {
 
         let run_id = Uuid::now_v7();
         let attempt = 3;
-        let workflow_run_state = runtime_state.workflow_run_state(run_id, attempt).await?;
+        let workflow_run_state = runtime_state
+            .get_workflow_run_state(run_id, attempt)
+            .await?;
 
         let metadata = HashMap::from_iter([("foo".to_string(), "bar".to_string())]);
         workflow_run_state.add_metadata(metadata.clone()).await?;
@@ -647,7 +762,9 @@ mod tests {
 
         let run_id = Uuid::now_v7();
         let attempt = 4;
-        let workflow_run_state = runtime_state.workflow_run_state(run_id, attempt).await?;
+        let workflow_run_state = runtime_state
+            .get_workflow_run_state(run_id, attempt)
+            .await?;
 
         let mut metadata1 = HashMap::from_iter([("foo".to_string(), "bar".to_string())]);
         workflow_run_state.add_metadata(metadata1.clone()).await?;


### PR DESCRIPTION
Add support for saving and loading workflows and inputs to the state interface and implementations.

Note that I have saved the workflows directly in the storage itself, but it may make more sense to save them as separate assets in an asset storage implementation?