### PR TITLE
chore: Revert CLI tool to python implementation

### DIFF
--- a/tierkreis/Cargo.toml
+++ b/tierkreis/Cargo.toml
@@ -6,8 +6,9 @@ edition = "2024"
 [lib]
 crate-type = ["rlib", "cdylib"]
 
-[[bin]]
-name = "tkr"
+# Disabled until feature-parity with the existing CLI tool.
+# [[bin]]
+# name = "tkr"
 
 [dependencies]
 axum = { version = "0.8.8", features = ["ws", "http2"] }

--- a/tierkreis/pyproject.toml
+++ b/tierkreis/pyproject.toml
@@ -57,3 +57,4 @@ publishing-environment = "pypi"
 
 [project.scripts]
 tkr-builtins = "tierkreis.builtins.main:main"
+tkr = "tierkreis.cli.tkr:main"


### PR DESCRIPTION
Revert the CLI tool to be the original python version for now as the Rust version is very feature-incomplete.