### PR TITLE
feat: async AssetStorage methods

### DIFF
--- a/tierkreis/Cargo.toml
+++ b/tierkreis/Cargo.toml
@@ -31,7 +31,7 @@ serde_json = "1.0.149"
 libsqlite3-sys = { version = "0.35.0", features = ["bundled"] }
 tempfile = "3.27.0"
 thiserror = "2.0.18"
-tokio = { version = "1.50.0", features = ["net", "process", "rt-multi-thread", "signal"] }
+tokio = { version = "1.50.0", features = ["net", "fs", "process", "rt-multi-thread", "signal"] }
 tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.23", features = ["fmt"] }
 url = "2.5.8"

--- a/tierkreis/src/asset_storage.rs
+++ b/tierkreis/src/asset_storage.rs
@@ -12,12 +12,10 @@ pub use crate::asset_storage::inmemory::InMemoryStorage;
 pub use crate::asset_storage::interface::{AssetKey, AssetKind, AssetSpec, AssetStorage};
 
 use std::hash::BuildHasher;
-use std::{
-    collections::HashMap,
-    sync::{Arc, RwLock},
-};
+use std::{collections::HashMap, sync::Arc};
 
 use miette::{Context, IntoDiagnostic, miette};
+use tokio::sync::RwLock;
 
 /// [`AssetStorageRegistry`] is sharable mapping of configured [`AssetStorage`] names
 /// to various implementations.
@@ -34,26 +32,22 @@ pub type AssetStorageRegistry = Arc<RwLock<HashMap<String, Box<dyn AssetStorage>
 ///
 /// Will return Err if the [`AssetStorageRegistry`] cannot be read from or if
 /// an [`AssetStorage`] with the specified name does not exist in the registry.
-pub fn load_assets<S: BuildHasher>(
+pub async fn load_assets<S: BuildHasher>(
     registry: &AssetStorageRegistry,
     assets: &HashMap<String, AssetSpec, S>,
 ) -> miette::Result<HashMap<String, Vec<u8>>> {
-    let registry = registry
-        .read()
-        .map_err(|err| miette!("Failed to read AssetStorageRegistry: {err}"))?;
-    assets
-        .iter()
-        .map(|(k, v)| {
-            let storage_name = &v.storage_name;
-            let storage = registry.get(storage_name).ok_or_else(|| {
-                miette!(
-                    "Cannot find AssetStorage in AssetStorageRegistry with name: {storage_name}"
-                )
-            })?;
-            let asset = storage.load(&v.asset_key)?;
-            Ok((k.clone(), asset))
-        })
-        .collect()
+    let registry = registry.read().await;
+
+    let mut loaded = HashMap::new();
+    for (k, v) in assets {
+        let storage_name = &v.storage_name;
+        let storage = registry.get(storage_name).ok_or_else(|| {
+            miette!("Cannot find AssetStorage in AssetStorageRegistry with name: {storage_name}")
+        })?;
+        let asset = storage.load(&v.asset_key).await?;
+        loaded.insert(k.clone(), asset);
+    }
+    Ok(loaded)
 }
 
 /// Load a single asset by name from the various [`AssetStorage`] implementations that
@@ -63,14 +57,12 @@ pub fn load_assets<S: BuildHasher>(
 ///
 /// Will return Err if the [`AssetStorageRegistry`] cannot be read from or if
 /// an [`AssetStorage`] with the specified name does not exist in the registry.
-pub fn load_asset<S: BuildHasher>(
+pub async fn load_asset<S: BuildHasher>(
     registry: &AssetStorageRegistry,
     assets: &HashMap<String, AssetSpec, S>,
     name: &str,
 ) -> miette::Result<Vec<u8>> {
-    let registry = registry
-        .read()
-        .map_err(|err| miette!("Failed to read AssetStorageRegistry: {err}"))?;
+    let registry = registry.read().await;
     let asset_spec = assets
         .get(name)
         .ok_or_else(|| miette!("Failed to find asset with name: `{name}`"))?;
@@ -80,7 +72,7 @@ pub fn load_asset<S: BuildHasher>(
         miette!("Cannot find AssetStorage in AssetStorageRegistry with name: {storage_name}")
     })?;
 
-    let asset = storage.load(&asset_spec.asset_key)?;
+    let asset = storage.load(&asset_spec.asset_key).await?;
 
     Ok(asset)
 }
@@ -95,14 +87,12 @@ pub fn load_asset<S: BuildHasher>(
 ///
 /// Will return Err if the [`AssetStorageRegistry`] cannot be read from or if
 /// an [`AssetStorage`] with the specified name does not exist in the registry.
-pub fn unfold_asset<S: BuildHasher>(
+pub async fn unfold_asset<S: BuildHasher>(
     registry: &AssetStorageRegistry,
     assets: &HashMap<String, AssetSpec, S>,
     name: &str,
 ) -> miette::Result<Vec<AssetSpec>> {
-    let registry = registry
-        .read()
-        .map_err(|err| miette!("Failed to read AssetStorageRegistry: {err}"))?;
+    let registry = registry.read().await;
     let asset_spec = assets
         .get(name)
         .ok_or_else(|| miette!("Failed to find asset with name: `{name}`"))?;
@@ -112,25 +102,23 @@ pub fn unfold_asset<S: BuildHasher>(
         miette!("Cannot find AssetStorage in AssetStorageRegistry with name: {storage_name}")
     })?;
 
-    let asset = storage.load(&asset_spec.asset_key)?;
+    let asset = storage.load(&asset_spec.asset_key).await?;
 
     let asset_value_list: Vec<serde_json::Value> =
         serde_json::from_slice(&asset).map_err(|err| miette!("Could not unfold asset: {err}"))?;
 
-    let asset_spec_list = asset_value_list
-        .into_iter()
-        .map(|asset_value| {
-            let asset_key = AssetKey::new();
-            let asset_bytes = serde_json::to_vec(&asset_value).into_diagnostic()?;
-            storage.save(&asset_key, asset_bytes)?;
+    let mut asset_spec_list = Vec::new();
+    for asset_value in asset_value_list {
+        let asset_key = AssetKey::new();
+        let asset_bytes = serde_json::to_vec(&asset_value).into_diagnostic()?;
+        storage.save(&asset_key, asset_bytes).await?;
 
-            Ok(AssetSpec {
-                kind: storage.kind(),
-                asset_key,
-                storage_name: storage_name.clone(),
-            })
-        })
-        .collect::<miette::Result<Vec<_>>>()?;
+        asset_spec_list.push(AssetSpec {
+            kind: storage.kind(),
+            storage_name: storage_name.clone(),
+            asset_key,
+        });
+    }
 
     Ok(asset_spec_list)
 }
@@ -143,33 +131,31 @@ pub fn unfold_asset<S: BuildHasher>(
 ///
 /// Will return Err if the [`AssetStorageRegistry`] cannot be read from or if
 /// an [`AssetStorage`] with the specified name does not exist in the registry.
-pub fn save_assets<S: BuildHasher>(
+pub async fn save_assets<S: BuildHasher>(
     registry: &AssetStorageRegistry,
     storage_name: &str,
-    asset_bytes: HashMap<String, Vec<u8>, S>,
+    raw_assets: HashMap<String, Vec<u8>, S>,
 ) -> miette::Result<HashMap<String, AssetSpec>> {
-    let registry = registry
-        .read()
-        .map_err(|err| miette!("Failed to read AssetStorageRegistry: {err}"))?;
+    let registry = registry.read().await;
     let storage = registry.get(storage_name).ok_or_else(|| {
         miette!("Cannot find AssetStorage in AssetStorageRegistry with name: {storage_name}")
     })?;
 
-    asset_bytes
-        .into_iter()
-        .map(|(k, v)| {
-            let asset_key = AssetKey::new();
-            storage.save(&asset_key, v)?;
-            Ok((
-                k,
-                AssetSpec {
-                    kind: storage.kind(),
-                    asset_key,
-                    storage_name: storage_name.to_string(),
-                },
-            ))
-        })
-        .collect()
+    let mut asset_specs = HashMap::new();
+    for (name, raw_asset) in raw_assets {
+        let asset_key = AssetKey::new();
+        storage.save(&asset_key, raw_asset).await?;
+        asset_specs.insert(
+            name,
+            AssetSpec {
+                kind: storage.kind(),
+                storage_name: storage_name.to_string(),
+                asset_key,
+            },
+        );
+    }
+
+    Ok(asset_specs)
 }
 
 /// Save an asset into an [`AssetStorage`] in the [`AssetStorageRegistry`] with a given name
@@ -179,20 +165,18 @@ pub fn save_assets<S: BuildHasher>(
 ///
 /// Will return Err if the [`AssetStorageRegistry`] cannot be read from or if
 /// an [`AssetStorage`] with the specified name does not exist in the registry.
-pub fn save_asset(
+pub async fn save_asset(
     registry: &AssetStorageRegistry,
     storage_name: &str,
     value: Vec<u8>,
 ) -> miette::Result<AssetSpec> {
-    let registry = registry
-        .read()
-        .map_err(|err| miette!("Failed to read AssetStorageRegistry: {err}"))?;
+    let registry = registry.read().await;
     let storage = registry.get(storage_name).ok_or_else(|| {
         miette!("Cannot find AssetStorage in AssetStorageRegistry with name: {storage_name}")
     })?;
 
     let asset_key = AssetKey::new();
-    storage.save(&asset_key, value)?;
+    storage.save(&asset_key, value).await?;
 
     Ok(AssetSpec {
         kind: storage.kind(),
@@ -209,39 +193,32 @@ pub fn save_asset(
 ///
 /// Will return Err if the [`AssetStorageRegistry`] cannot be read from or if
 /// an [`AssetStorage`] with the specified name does not exist in the registry.
-pub fn fold_assets(
+pub async fn fold_assets(
     registry: &AssetStorageRegistry,
     storage_name: &str,
-    assets: impl IntoIterator<Item = AssetSpec>,
+    asset_specs: impl IntoIterator<Item = AssetSpec>,
 ) -> miette::Result<AssetSpec> {
-    let registry = registry
-        .read()
-        .map_err(|err| miette!("Failed to read AssetStorageRegistry: {err}"))?;
+    let registry = registry.read().await;
 
-    let asset_values = assets
-        .into_iter()
-        .map(|asset_spec| {
-            let storage_name = &asset_spec.storage_name;
-            let storage = registry.get(&asset_spec.storage_name).ok_or_else(|| {
-                miette!(
-                    "Cannot find AssetStorage in AssetStorageRegistry with name: {storage_name}"
-                )
-            })?;
+    let mut asset_values = Vec::new();
+    for asset_spec in asset_specs {
+        let storage_name = &asset_spec.storage_name;
+        let storage = registry.get(&asset_spec.storage_name).ok_or_else(|| {
+            miette!("Cannot find AssetStorage in AssetStorageRegistry with name: {storage_name}")
+        })?;
 
-            let asset = storage.load(&asset_spec.asset_key)?;
-            let asset_value: serde_json::Value =
-                serde_json::from_slice(&asset).into_diagnostic()?;
+        let asset = storage.load(&asset_spec.asset_key).await?;
+        let asset_value: serde_json::Value = serde_json::from_slice(&asset).into_diagnostic()?;
 
-            Ok(asset_value)
-        })
-        .collect::<miette::Result<Vec<_>>>()?;
+        asset_values.push(asset_value);
+    }
 
     let storage = registry.get(storage_name).ok_or_else(|| {
         miette!("Cannot find AssetStorage in AssetStorageRegistry with name: {storage_name}")
     })?;
     let asset_key = AssetKey::new();
     let asset_bytes = serde_json::to_vec(&asset_values).into_diagnostic()?;
-    storage.save(&asset_key, asset_bytes)?;
+    storage.save(&asset_key, asset_bytes).await?;
 
     Ok(AssetSpec {
         kind: storage.kind(),
@@ -258,44 +235,47 @@ pub fn fold_assets(
 /// Will return Err if the [`AssetStorageRegistry`] cannot be read from or if
 /// an [`AssetStorage`] with the specified name does not exist in the registry
 /// or if the [`AssetSpec`]s provided cannot be retrieved from the [`AssetStorageRegistry`].
-pub fn transfer_assets<S: BuildHasher>(
+pub async fn transfer_assets<S: BuildHasher>(
     registry: &AssetStorageRegistry,
     storage_name_to: &str,
     assets_from: &HashMap<String, AssetSpec, S>,
 ) -> miette::Result<HashMap<String, AssetSpec>> {
-    let registry = registry
-        .read()
-        .map_err(|err| miette!("Failed to read AssetStorageRegistry: {err}"))?;
+    let registry = registry.read().await;
     let storage_to = registry.get(storage_name_to).ok_or_else(|| {
         miette!("Cannot find AssetStorage in AssetStorageRegistry with name: {storage_name_to}")
     })?;
 
-    assets_from
-        .iter()
-        .map(|(k, v)| {
-            if v.storage_name == storage_name_to {
-                Ok((k.clone(), v.clone()))
-            } else {
-                let storage_name_from = &v.storage_name;
-                let storage_from = registry.get(storage_name_from).ok_or_else(|| miette!(
+    let mut transferred = HashMap::new();
+    for (name, asset_from) in assets_from {
+        if asset_from.storage_name == storage_name_to {
+            transferred.insert(name.clone(), asset_from.clone());
+        } else {
+            let storage_name_from = &asset_from.storage_name;
+            let storage_from = registry.get(storage_name_from).ok_or_else(|| miette!(
                     "Cannot find AssetStorage in AssetStorageRegistry with name: {storage_name_from}"
                 ))?;
 
-                let asset = storage_from.load(&v.asset_key).wrap_err("Failed to load asset")?;
+            let asset = storage_from
+                .load(&asset_from.asset_key)
+                .await
+                .wrap_err("Failed to load asset")?;
 
-                let asset_key = AssetKey::new();
-                storage_to.save(&asset_key, asset).wrap_err("Failed to save asset")?;
-                Ok((
-                    k.clone(),
-                    AssetSpec {
-                        kind: storage_to.kind(),
-                        asset_key,
-                        storage_name: storage_name_to.to_string(),
-                    },
-                ))
-            }
-        })
-        .collect()
+            let asset_key = AssetKey::new();
+            storage_to
+                .save(&asset_key, asset)
+                .await
+                .wrap_err("Failed to save asset")?;
+            transferred.insert(
+                name.clone(),
+                AssetSpec {
+                    kind: storage_to.kind(),
+                    asset_key,
+                    storage_name: storage_name_to.to_string(),
+                },
+            );
+        }
+    }
+    Ok(transferred)
 }
 
 /// Generate a `total` number of [`AssetSpec`]s for use as Task outputs or similar.
@@ -304,14 +284,13 @@ pub fn transfer_assets<S: BuildHasher>(
 ///
 /// Will return Err if the [`AssetStorageRegistry`] cannot be read from or if
 /// an [`AssetStorage`] with the specified name does not exist in the registry.
-pub fn reserve_asset_specs(
+pub async fn reserve_asset_specs(
     registry: &AssetStorageRegistry,
     storage_name: &str,
     total: usize,
 ) -> miette::Result<Vec<AssetSpec>> {
-    let registry = registry
-        .read()
-        .map_err(|err| miette!("Failed to read AssetStorageRegistry: {err}"))?;
+    let registry = registry.read().await;
+
     let storage = registry.get(storage_name).ok_or_else(|| {
         miette!("Cannot find AssetStorage in AssetStorageRegistry with name: {storage_name}")
     })?;
@@ -334,7 +313,7 @@ pub fn reserve_asset_specs(
 ///
 /// Will panic if the input assets are not dictionaries or they cannot be saved.
 #[cfg(test)]
-pub fn test_storage_registry(
+pub async fn test_storage_registry(
     assets_for_memory: impl IntoIterator<Item = serde_json::Value>,
     assets_for_files: impl IntoIterator<Item = serde_json::Value>,
 ) -> (
@@ -360,7 +339,7 @@ pub fn test_storage_registry(
         for (name, value) in inputs {
             let asset_key = AssetKey::new();
             let asset = serde_json::to_vec(&value).unwrap();
-            memory_storage.save(&asset_key, asset).unwrap();
+            memory_storage.save(&asset_key, asset).await.unwrap();
             input_assets.insert(
                 name,
                 AssetSpec {
@@ -385,7 +364,7 @@ pub fn test_storage_registry(
         for (name, value) in inputs {
             let asset_key = AssetKey::new();
             let asset = serde_json::to_vec(&value).unwrap();
-            file_storage.save(&asset_key, asset).unwrap();
+            file_storage.save(&asset_key, asset).await.unwrap();
             input_assets.insert(
                 name,
                 AssetSpec {
@@ -413,13 +392,13 @@ pub fn test_storage_registry(
 ///
 /// Will panic if outputs do not match the expected Value.
 #[cfg(test)]
-pub fn assert_registry_contains_values<S: BuildHasher>(
+pub async fn assert_registry_contains_values<S: BuildHasher>(
     registry: &AssetStorageRegistry,
     storage_name: &str,
     outputs: &HashMap<String, AssetSpec, S>,
     expected: serde_json::Value,
 ) {
-    let registry = registry.read().unwrap();
+    let registry = registry.read().await;
     let storage = registry.get(storage_name).unwrap();
 
     let expected: HashMap<String, serde_json::Value> =
@@ -431,6 +410,7 @@ pub fn assert_registry_contains_values<S: BuildHasher>(
     for (k, v) in outputs {
         let asset = storage
             .load(&v.asset_key)
+            .await
             .unwrap_or_else(|err| panic!("Failed to load: {err}"));
         let value: serde_json::Value = serde_json::from_slice(&asset).unwrap();
         assert_eq!(

--- a/tierkreis/src/asset_storage/file.rs
+++ b/tierkreis/src/asset_storage/file.rs
@@ -3,13 +3,14 @@ This module defines the [`FileAssetStorage`] struct which implements [`AssetStor
 by storing files in a single directory.
 */
 
-use std::{
-    fs::File,
-    io::{Read, Write},
-    path::{Path, PathBuf},
-};
+use std::path::{Path, PathBuf};
 
+use futures::future::{BoxFuture, FutureExt};
 use miette::{Context, IntoDiagnostic, miette};
+use tokio::{
+    fs::File,
+    io::{AsyncReadExt, AsyncWriteExt},
+};
 
 use crate::asset_storage::interface::{AssetKey, AssetKind, AssetStorage};
 
@@ -41,29 +42,47 @@ impl AssetStorage for FileAssetStorage {
         }
     }
 
-    fn exists(&self, key: &AssetKey) -> miette::Result<bool> {
+    fn exists(&self, key: &AssetKey) -> BoxFuture<'_, miette::Result<bool>> {
         let location = self.location(key);
-        location.try_exists().into_diagnostic().wrap_err_with(|| {
-            miette!("Could not determine whether file exists at location: {location:?}")
-        })
+        async move {
+            tokio::fs::try_exists(&location)
+                .await
+                .into_diagnostic()
+                .wrap_err_with(|| {
+                    miette!("Could not determine whether file exists at location: {location:?}")
+                })
+        }
+        .boxed()
     }
 
-    fn save(&self, key: &AssetKey, value: Vec<u8>) -> miette::Result<()> {
+    fn save(&self, key: &AssetKey, value: Vec<u8>) -> BoxFuture<'_, miette::Result<()>> {
         let location = self.location(key);
-        let mut file = File::create(self.location(key))
-            .into_diagnostic()
-            .wrap_err_with(|| miette!("Cannot find file at location: {location:?}"))?;
-        file.write_all(&value).into_diagnostic()?;
-        Ok(())
+        async move {
+            let mut file = File::create(&location)
+                .await
+                .into_diagnostic()
+                .wrap_err_with(|| miette!("Cannot find file at location: {location:?}"))?;
+
+            file.write_all(&value).await.into_diagnostic()?;
+
+            Ok(())
+        }
+        .boxed()
     }
 
-    fn load(&self, key: &AssetKey) -> miette::Result<Vec<u8>> {
+    fn load(&self, key: &AssetKey) -> BoxFuture<'_, miette::Result<Vec<u8>>> {
         let location = self.location(key);
-        let mut file = File::open(self.location(key))
-            .into_diagnostic()
-            .wrap_err_with(|| miette!("Cannot find file at location: {location:?}"))?;
-        let mut value = Vec::new();
-        file.read_to_end(&mut value).into_diagnostic()?;
-        Ok(value)
+        async move {
+            let mut file = File::open(&location)
+                .await
+                .into_diagnostic()
+                .wrap_err_with(|| miette!("Cannot find file at location: {location:?}"))?;
+
+            let mut value = Vec::new();
+            file.read_to_end(&mut value).await.into_diagnostic()?;
+
+            Ok(value)
+        }
+        .boxed()
     }
 }

--- a/tierkreis/src/asset_storage/inmemory.rs
+++ b/tierkreis/src/asset_storage/inmemory.rs
@@ -3,6 +3,10 @@ This module defines the [`InMemoryStorage`] struct which implements [`AssetStora
 by storing files in concurrent map data structure implemented by [`dashmap::DashMap`].
 */
 use dashmap::DashMap;
+use futures::{
+    FutureExt,
+    future::{self, BoxFuture},
+};
 use miette::miette;
 
 use crate::asset_storage::interface::{AssetKey, AssetKind, AssetStorage};
@@ -37,20 +41,20 @@ impl AssetStorage for InMemoryStorage {
         AssetKind::Memory
     }
 
-    fn exists(&self, key: &AssetKey) -> miette::Result<bool> {
-        Ok(self.store.contains_key(key))
+    fn exists(&self, key: &AssetKey) -> BoxFuture<'_, miette::Result<bool>> {
+        future::ok(self.store.contains_key(key)).boxed()
     }
 
-    fn save(&self, key: &AssetKey, value: Vec<u8>) -> miette::Result<()> {
+    fn save(&self, key: &AssetKey, value: Vec<u8>) -> BoxFuture<'_, miette::Result<()>> {
         self.store.insert(*key, value);
-        Ok(())
+        future::ok(()).boxed()
     }
 
-    fn load(&self, key: &AssetKey) -> miette::Result<Vec<u8>> {
-        let value = self
+    fn load(&self, key: &AssetKey) -> BoxFuture<'_, miette::Result<Vec<u8>>> {
+        let res = self
             .store
             .get(key)
-            .ok_or_else(|| miette!("Asset not found in InMemoryStorage"))?;
-        Ok(value.clone())
+            .ok_or_else(|| miette!("Asset not found in InMemoryStorage"));
+        future::ready(res.map(|x| x.clone())).boxed()
     }
 }

--- a/tierkreis/src/asset_storage/interface.rs
+++ b/tierkreis/src/asset_storage/interface.rs
@@ -4,6 +4,7 @@ implementations must satisfy.
 */
 use std::{fmt::Display, path::PathBuf, str::FromStr, time::SystemTime};
 
+use futures::future::BoxFuture;
 use miette::{Context, IntoDiagnostic, miette};
 use url::Url;
 use uuid::Uuid;
@@ -152,19 +153,19 @@ pub trait AssetStorage: Send + Sync {
     /// # Errors
     ///
     /// Will return Err if the data backing the [`AssetStorage`] is unreachable or busy.
-    fn exists(&self, key: &AssetKey) -> miette::Result<bool>;
+    fn exists(&self, key: &AssetKey) -> BoxFuture<'_, miette::Result<bool>>;
     /// Save an Asset to the [`AssetStorage`] using an [`AssetKey`].
     ///
     /// # Errors
     ///
     /// Will return Err if the data backing the [`AssetStorage`] is unreachable or busy.
-    fn save(&self, key: &AssetKey, value: Vec<u8>) -> miette::Result<()>;
+    fn save(&self, key: &AssetKey, value: Vec<u8>) -> BoxFuture<'_, miette::Result<()>>;
     /// Load an Asset from the [`AssetStorage`] using an [`AssetKey`].
     ///
     /// # Errors
     ///
     /// Will return Err if the data backing the [`AssetStorage`] is unreachable or busy.
-    fn load(&self, key: &AssetKey) -> miette::Result<Vec<u8>>;
+    fn load(&self, key: &AssetKey) -> BoxFuture<'_, miette::Result<Vec<u8>>>;
 }
 
 #[cfg(test)]

--- a/tierkreis/src/executor/inmemory.rs
+++ b/tierkreis/src/executor/inmemory.rs
@@ -246,7 +246,7 @@ async fn process_finished_task(
         }
     };
 
-    let outputs = save_assets(asset_storage_registry, &output_storage_name, outputs);
+    let outputs = save_assets(asset_storage_registry, &output_storage_name, outputs).await;
     match outputs {
         Ok(outputs) => send_complete(event_sender, vec![loc], vec![outputs]).await?,
         Err(err) => send_error(event_sender, loc, &err).await?,
@@ -267,7 +267,7 @@ async fn start_task(
     let output_storage_name = internal_task.output_storage_name;
     send_running(event_sender, loc.clone()).await?;
 
-    let res = load_assets(asset_storage_registry, &task_plan.inputs);
+    let res = load_assets(asset_storage_registry, &task_plan.inputs).await;
 
     let inputs = match res {
         Ok(inputs) => inputs,
@@ -364,13 +364,11 @@ impl InMemoryExecutor {
     ///
     /// This function will return Err if the specified `output_storage_name` does not exist
     /// inside the [`AssetStorageRegistry`].
-    pub fn try_new(
+    pub async fn try_new(
         asset_storage_registry: &AssetStorageRegistry,
         output_storage_name: &str,
     ) -> miette::Result<Self> {
-        let asset_storage_registry_lock = asset_storage_registry
-            .read()
-            .map_err(|err| miette!("Failed to lock AssetStorageRegistry for reading: {err}"))?;
+        let asset_storage_registry_lock = asset_storage_registry.read().await;
         if !asset_storage_registry_lock.contains_key(output_storage_name) {
             return Err(miette!("output_storage_name not in registry"));
         }
@@ -472,8 +470,8 @@ mod tests {
 
     #[tokio::test]
     async fn inmemory_workers() -> miette::Result<()> {
-        let (registry, _, _) = test_storage_registry(vec![], vec![]);
-        let executor = InMemoryExecutor::try_new(&registry, "memory")?;
+        let (registry, _, _) = test_storage_registry(vec![], vec![]).await;
+        let executor = InMemoryExecutor::try_new(&registry, "memory").await?;
 
         let workers = executor.workers().await?;
 
@@ -495,7 +493,7 @@ mod tests {
     #[tokio::test]
     async fn execute_inmemory(#[case] default_storage_name: &str) -> miette::Result<()> {
         let (registry, input_sets, _dir) =
-            test_storage_registry(vec![json!({"a": 1, "b": 3})], vec![]);
+            test_storage_registry(vec![json!({"a": 1, "b": 3})], vec![]).await;
 
         let task_plans = vec![TaskPlan {
             worker_name: "builtin".to_string(),
@@ -505,7 +503,7 @@ mod tests {
 
             ..Default::default()
         }];
-        let executor = InMemoryExecutor::try_new(&registry, default_storage_name)?;
+        let executor = InMemoryExecutor::try_new(&registry, default_storage_name).await?;
 
         let stream = executor.listen()?;
         executor.execute(task_plans).await?;
@@ -532,7 +530,8 @@ mod tests {
             default_storage_name,
             &events[1].clone().outputs()[0],
             json!({"value": 4}),
-        );
+        )
+        .await;
 
         Ok(())
     }
@@ -548,7 +547,7 @@ mod tests {
         #[case] default_storage_name: &str,
     ) -> miette::Result<()> {
         let (registry, input_sets, _dir) =
-            test_storage_registry(vec![], vec![json!({"a": 1, "b": 3})]);
+            test_storage_registry(vec![], vec![json!({"a": 1, "b": 3})]).await;
 
         let task_plans = vec![TaskPlan {
             worker_name: "builtin".to_string(),
@@ -558,7 +557,7 @@ mod tests {
 
             ..Default::default()
         }];
-        let executor = InMemoryExecutor::try_new(&registry, default_storage_name)?;
+        let executor = InMemoryExecutor::try_new(&registry, default_storage_name).await?;
 
         let stream = executor.listen()?;
         executor.execute(task_plans).await?;
@@ -584,7 +583,8 @@ mod tests {
             default_storage_name,
             &events[1].clone().outputs()[0],
             json!({"value": 4}),
-        );
+        )
+        .await;
 
         Ok(())
     }
@@ -599,7 +599,8 @@ mod tests {
         let (registry, input_sets, _dir) = test_storage_registry(
             vec![json!({"a": 1, "b": 3}), json!({"a": 4, "b": 8})],
             vec![],
-        );
+        )
+        .await;
 
         let loc1 = Location::from_usize_iter([0]);
         let loc2 = Location::from_usize_iter([1]);
@@ -623,7 +624,7 @@ mod tests {
                 ..Default::default()
             },
         ];
-        let executor = InMemoryExecutor::try_new(&registry, default_storage_name)?;
+        let executor = InMemoryExecutor::try_new(&registry, default_storage_name).await?;
 
         let stream = executor.listen()?;
         executor.execute(task_plans).await?;
@@ -657,7 +658,8 @@ mod tests {
             default_storage_name,
             &complete0.clone().outputs()[0],
             json!({"value": 4}),
-        );
+        )
+        .await;
         let complete1 = events
             .iter()
             .find(|event| {
@@ -675,7 +677,8 @@ mod tests {
             default_storage_name,
             &complete1.clone().outputs()[0],
             json!({"value": 12}),
-        );
+        )
+        .await;
 
         Ok(())
     }
@@ -686,7 +689,7 @@ mod tests {
     #[tokio::test]
     async fn execute_inmemory_execute_before_listen() -> miette::Result<()> {
         let (registry, input_sets, _) =
-            test_storage_registry(vec![json!({"a": 1, "b": 3})], vec![]);
+            test_storage_registry(vec![json!({"a": 1, "b": 3})], vec![]).await;
 
         let task_plans = vec![TaskPlan {
             worker_name: "builtin".to_string(),
@@ -696,7 +699,7 @@ mod tests {
 
             ..Default::default()
         }];
-        let executor = InMemoryExecutor::try_new(&registry, "memory")?;
+        let executor = InMemoryExecutor::try_new(&registry, "memory").await?;
 
         executor.execute(task_plans).await?;
         let stream = executor.listen()?;
@@ -722,7 +725,8 @@ mod tests {
             "memory",
             &events[1].clone().outputs()[0],
             json!({"value": 4}),
-        );
+        )
+        .await;
 
         Ok(())
     }
@@ -731,7 +735,7 @@ mod tests {
     // errors when they occur
     #[tokio::test]
     async fn execute_inmemory_error() -> miette::Result<()> {
-        let (registry, _, _) = test_storage_registry(vec![], vec![]);
+        let (registry, _, _) = test_storage_registry(vec![], vec![]).await;
         let task_plans = vec![TaskPlan {
             worker_name: "builtin".to_string(),
             // builtin-worker has no task called "backflip"
@@ -741,7 +745,7 @@ mod tests {
 
             ..Default::default()
         }];
-        let executor = InMemoryExecutor::try_new(&registry, "memory")?;
+        let executor = InMemoryExecutor::try_new(&registry, "memory").await?;
 
         let stream = executor.listen()?;
         executor.execute(task_plans).await?;
@@ -775,7 +779,7 @@ mod tests {
     #[tokio::test]
     async fn execute_inmemory_cancel() -> miette::Result<()> {
         let (registry, input_sets, _) =
-            test_storage_registry(vec![json!({"delay_seconds": 1})], vec![]);
+            test_storage_registry(vec![json!({"delay_seconds": 1})], vec![]).await;
 
         let loc = Location::from_usize_iter([0]);
         let task_plans = vec![TaskPlan {
@@ -787,7 +791,7 @@ mod tests {
 
             ..Default::default()
         }];
-        let executor = InMemoryExecutor::try_new(&registry, "memory")?;
+        let executor = InMemoryExecutor::try_new(&registry, "memory").await?;
 
         let mut stream = executor.listen()?;
         executor.execute(task_plans).await?;
@@ -819,8 +823,8 @@ mod tests {
     // it will not error.
     #[tokio::test]
     async fn execute_inmemory_cancel_non_existent() -> miette::Result<()> {
-        let (registry, _, _) = test_storage_registry(vec![], vec![]);
-        let executor = InMemoryExecutor::try_new(&registry, "memory")?;
+        let (registry, _, _) = test_storage_registry(vec![], vec![]).await;
+        let executor = InMemoryExecutor::try_new(&registry, "memory").await?;
 
         let loc = Location::from_usize_iter([0]);
         executor.cancel(vec![loc]).await?;
@@ -833,7 +837,7 @@ mod tests {
     #[tokio::test]
     async fn execute_inmemory_cancel_completed() -> miette::Result<()> {
         let (registry, input_sets, _) =
-            test_storage_registry(vec![json!({"a": 1, "b": 3})], vec![]);
+            test_storage_registry(vec![json!({"a": 1, "b": 3})], vec![]).await;
 
         let loc = Location::from_usize_iter([0]);
         let task_plans = vec![TaskPlan {
@@ -845,7 +849,7 @@ mod tests {
 
             ..Default::default()
         }];
-        let executor = InMemoryExecutor::try_new(&registry, "memory")?;
+        let executor = InMemoryExecutor::try_new(&registry, "memory").await?;
 
         let stream = executor.listen()?;
         executor.execute(task_plans).await?;
@@ -871,7 +875,8 @@ mod tests {
             "memory",
             &events[1].clone().outputs()[0],
             json!({"value": 4}),
-        );
+        )
+        .await;
 
         executor.cancel(vec![loc]).await?;
 

--- a/tierkreis/src/executor/subprocess.rs
+++ b/tierkreis/src/executor/subprocess.rs
@@ -104,7 +104,7 @@ async fn process_finished_task(
         Ok(status) => {
             if status.success() {
                 let outputs =
-                    transfer_assets(asset_storage_registry, &output_storage_name, &outputs);
+                    transfer_assets(asset_storage_registry, &output_storage_name, &outputs).await;
                 match outputs {
                     Ok(outputs) => send_complete(event_sender, vec![loc], vec![outputs]).await?,
                     Err(err) => send_error(event_sender, loc, &err).await?,
@@ -251,14 +251,12 @@ impl SubprocessExecutor {
     ///
     /// This function will return Err if the specified `subprocess_storage_name` or
     /// `output_storage_name` does not exist inside the [`AssetStorageRegistry`].
-    pub fn try_new(
+    pub async fn try_new(
         asset_storage_registry: &AssetStorageRegistry,
         subprocess_storage_name: &str,
         output_storage_name: &str,
     ) -> miette::Result<Self> {
-        let asset_storage_registry_lock = asset_storage_registry
-            .read()
-            .map_err(|err| miette!("Failed to lock AssetStorageRegistry for reading: {err}"))?;
+        let asset_storage_registry_lock = asset_storage_registry.read().await;
         if let Some(subprocess_storage) = asset_storage_registry_lock.get(subprocess_storage_name) {
             if !matches!(subprocess_storage.kind(), AssetKind::File { .. }) {
                 return Err(miette!(
@@ -312,7 +310,7 @@ impl SubprocessExecutor {
         task.await.into_diagnostic()?
     }
 
-    fn build_inputs(
+    async fn build_inputs(
         &self,
         inputs: &HashMap<String, AssetSpec>,
     ) -> Result<HashMap<String, PathBuf>, miette::Error> {
@@ -320,18 +318,20 @@ impl SubprocessExecutor {
             &self.asset_storage_registry,
             &self.subprocess_storage_name,
             inputs,
-        )?;
+        )
+        .await?;
         let inputs =
             write_input_paths(&inputs).wrap_err("Failed to collect Worker input filepaths")?;
         Ok(inputs)
     }
 
-    fn build_outputs(&self, outputs: HashSet<String>) -> Result<OutputSpecs, miette::Error> {
+    async fn build_outputs(&self, outputs: HashSet<String>) -> Result<OutputSpecs, miette::Error> {
         let output_specs = reserve_asset_specs(
             &self.asset_storage_registry,
             &self.subprocess_storage_name,
             outputs.len(),
-        )?;
+        )
+        .await?;
         let outputs: HashMap<String, AssetSpec> = outputs.into_iter().zip(output_specs).collect();
         let output_paths = outputs
             .iter()
@@ -407,9 +407,11 @@ impl Executor for SubprocessExecutor {
             for task_plan in task_plans {
                 let inputs = self
                     .build_inputs(&task_plan.inputs)
+                    .await
                     .wrap_err("Failed to build task inputs")?;
                 let (outputs, output_paths) = self
                     .build_outputs(task_plan.outputs)
+                    .await
                     .wrap_err("Failed to build task outputs")?;
 
                 let worker_args = NamedTempFile::new()
@@ -507,8 +509,8 @@ mod tests {
     // Test that we can list the available workers in $PATH
     #[tokio::test]
     async fn subprocess_workers() -> miette::Result<()> {
-        let (registry, _, _) = test_storage_registry(vec![], vec![]);
-        let executor = SubprocessExecutor::try_new(&registry, "file", "file")?;
+        let (registry, _, _) = test_storage_registry(vec![], vec![]).await;
+        let executor = SubprocessExecutor::try_new(&registry, "file", "file").await?;
 
         let workers = executor.workers().await?;
 
@@ -540,7 +542,8 @@ mod tests {
         let (registry, input_sets, _dir) = test_storage_registry(
             vec![json!({"greeting": "hello ", "subject": "dave"})],
             vec![],
-        );
+        )
+        .await;
         let mut outputs = HashSet::new();
         outputs.insert("value".to_string());
 
@@ -552,7 +555,7 @@ mod tests {
             outputs,
             ..Default::default()
         }];
-        let executor = SubprocessExecutor::try_new(&registry, "file", output_storage_name)?;
+        let executor = SubprocessExecutor::try_new(&registry, "file", output_storage_name).await?;
 
         let stream = executor.listen()?;
         executor.execute(task_plans).await?;
@@ -578,7 +581,8 @@ mod tests {
             output_storage_name,
             &events[1].clone().outputs()[0],
             json!({"value": "hello dave"}),
-        );
+        )
+        .await;
 
         Ok(())
     }
@@ -596,7 +600,8 @@ mod tests {
         let (registry, input_sets, _dir) = test_storage_registry(
             vec![],
             vec![json!({"greeting": "hello ", "subject": "dave"})],
-        );
+        )
+        .await;
         let mut outputs = HashSet::new();
         outputs.insert("value".to_string());
 
@@ -609,7 +614,7 @@ mod tests {
 
             ..Default::default()
         }];
-        let executor = SubprocessExecutor::try_new(&registry, "file", output_storage_name)?;
+        let executor = SubprocessExecutor::try_new(&registry, "file", output_storage_name).await?;
 
         let stream = executor.listen()?;
         executor.execute(task_plans).await?;
@@ -635,7 +640,8 @@ mod tests {
             output_storage_name,
             &events[1].clone().outputs()[0],
             json!({"value": "hello dave"}),
-        );
+        )
+        .await;
 
         Ok(())
     }
@@ -653,7 +659,8 @@ mod tests {
                 json!({"greeting": "hi ", "subject": "steve"}),
             ],
             vec![],
-        );
+        )
+        .await;
         let mut outputs = HashSet::new();
         outputs.insert("value".to_string());
 
@@ -681,7 +688,7 @@ mod tests {
                 ..Default::default()
             },
         ];
-        let executor = SubprocessExecutor::try_new(&registry, "file", output_storage_name)?;
+        let executor = SubprocessExecutor::try_new(&registry, "file", output_storage_name).await?;
 
         let stream = executor.listen()?;
         executor.execute(task_plans).await?;
@@ -715,7 +722,8 @@ mod tests {
             output_storage_name,
             &complete0.clone().outputs()[0],
             json!({"value": "hello dave"}),
-        );
+        )
+        .await;
         let complete1 = events
             .iter()
             .find(|event| {
@@ -733,7 +741,8 @@ mod tests {
             output_storage_name,
             &complete1.clone().outputs()[0],
             json!({"value": "hi steve"}),
-        );
+        )
+        .await;
 
         Ok(())
     }
@@ -746,7 +755,8 @@ mod tests {
         let (registry, input_sets, _dir) = test_storage_registry(
             vec![json!({"greeting": "hello ", "subject": "dave"})],
             vec![],
-        );
+        )
+        .await;
         let mut outputs = HashSet::new();
         outputs.insert("value".to_string());
 
@@ -759,7 +769,7 @@ mod tests {
 
             ..Default::default()
         }];
-        let executor = SubprocessExecutor::try_new(&registry, "file", "file")?;
+        let executor = SubprocessExecutor::try_new(&registry, "file", "file").await?;
 
         executor.execute(task_plans).await?;
         let stream = executor.listen()?;
@@ -785,7 +795,8 @@ mod tests {
             "file",
             &events[1].clone().outputs()[0],
             json!({"value": "hello dave"}),
-        );
+        )
+        .await;
 
         Ok(())
     }
@@ -794,7 +805,7 @@ mod tests {
     // errors when they occur
     #[tokio::test]
     async fn execute_subprocess_error() -> miette::Result<()> {
-        let (registry, _, _dir) = test_storage_registry(vec![], vec![]);
+        let (registry, _, _dir) = test_storage_registry(vec![], vec![]).await;
         let task_plans = vec![TaskPlan {
             worker_name: "hello-world-worker".to_string(),
             // hello-world-worker has no task called "hail"
@@ -804,7 +815,7 @@ mod tests {
 
             ..Default::default()
         }];
-        let executor = SubprocessExecutor::try_new(&registry, "file", "file")?;
+        let executor = SubprocessExecutor::try_new(&registry, "file", "file").await?;
 
         let stream = executor.listen()?;
         executor.execute(task_plans).await?;
@@ -839,7 +850,8 @@ mod tests {
         let (registry, input_sets, _dir) = test_storage_registry(
             vec![json!({"greeting": "hello ", "subject": "dave"})],
             vec![],
-        );
+        )
+        .await;
         let mut outputs = HashSet::new();
         outputs.insert("value".to_string());
 
@@ -854,7 +866,7 @@ mod tests {
 
             ..Default::default()
         }];
-        let executor = SubprocessExecutor::try_new(&registry, "file", "file")?;
+        let executor = SubprocessExecutor::try_new(&registry, "file", "file").await?;
 
         let mut stream = executor.listen()?;
         executor.execute(task_plans).await?;
@@ -886,8 +898,8 @@ mod tests {
     // it will not error.
     #[tokio::test]
     async fn execute_subprocess_cancel_non_existent() -> miette::Result<()> {
-        let (registry, _, _) = test_storage_registry(vec![], vec![]);
-        let executor = SubprocessExecutor::try_new(&registry, "file", "file")?;
+        let (registry, _, _) = test_storage_registry(vec![], vec![]).await;
+        let executor = SubprocessExecutor::try_new(&registry, "file", "file").await?;
 
         let loc = Location::from_usize_iter([0]);
         executor.cancel(vec![loc]).await?;
@@ -902,7 +914,8 @@ mod tests {
         let (registry, input_sets, _dir) = test_storage_registry(
             vec![json!({"greeting": "hello ", "subject": "dave"})],
             vec![],
-        );
+        )
+        .await;
         let mut outputs = HashSet::new();
         outputs.insert("value".to_string());
 
@@ -917,7 +930,7 @@ mod tests {
 
             ..Default::default()
         }];
-        let executor = SubprocessExecutor::try_new(&registry, "file", "file")?;
+        let executor = SubprocessExecutor::try_new(&registry, "file", "file").await?;
 
         let stream = executor.listen()?;
         executor.execute(task_plans).await?;
@@ -943,7 +956,8 @@ mod tests {
             "file",
             &events[1].clone().outputs()[0],
             json!({"value": "hello dave"}),
-        );
+        )
+        .await;
 
         executor.cancel(vec![loc]).await?;
 

--- a/tierkreis/src/orchestrator.rs
+++ b/tierkreis/src/orchestrator.rs
@@ -155,7 +155,7 @@ impl Orchestrator {
     /// This function will return Err if the specified `default_storage_name` does not exist
     /// inside the [`AssetStorageRegistry`] or if the specified `default_executor_name` does
     /// not exist inside the [`ExecutorRegistry`].
-    pub fn try_new(
+    pub async fn try_new(
         asset_storage_registry: &AssetStorageRegistry,
         executor_registry: &ExecutorRegistry,
         default_storage_name: &str,
@@ -163,9 +163,7 @@ impl Orchestrator {
     ) -> miette::Result<Self> {
         let (sender, receiver) = mpsc::channel(128);
 
-        let asset_storage_registry_lock = asset_storage_registry
-            .read()
-            .map_err(|err| miette!("Failed to lock AssetStorageRegistry for reading: {err}"))?;
+        let asset_storage_registry_lock = asset_storage_registry.read().await;
         if !asset_storage_registry_lock.contains_key(default_storage_name) {
             return Err(miette!("default_storage_name not in registry"));
         }
@@ -232,9 +230,10 @@ impl Orchestrator {
                     NodeDefinition::Input { name } => stream_action_result(
                         Self::build_input_action(graph_inputs.clone(), loc, name),
                     ),
-                    NodeDefinition::Const { value } => {
-                        stream_action_result(self.build_const_action(loc, value.clone()))
-                    }
+                    NodeDefinition::Const { value } => self
+                        .build_const_action(loc, value.clone())
+                        .into_stream()
+                        .boxed_local(),
                     NodeDefinition::Output {} => self
                         .build_output_actions(workflow_graph.clone(), node_states.clone(), n, loc)
                         .try_flatten_stream()
@@ -284,21 +283,25 @@ impl Orchestrator {
                         .try_flatten_stream()
                         .boxed_local(),
                     // Eager and Lazy If else are controlled by the ready node checks
-                    NodeDefinition::IfElse {} => stream_action_result(self.build_if_else_action(
-                        workflow_graph.clone(),
-                        node_states.clone(),
-                        n,
-                        loc,
-                        state.cond,
-                    )),
-                    NodeDefinition::EagerIfElse {} => {
-                        stream_action_result(self.build_eager_if_else_action(
+                    NodeDefinition::IfElse {} => self
+                        .build_if_else_action(
                             workflow_graph.clone(),
                             node_states.clone(),
                             n,
                             loc,
-                        ))
-                    }
+                            state.cond,
+                        )
+                        .into_stream()
+                        .boxed_local(),
+                    NodeDefinition::EagerIfElse {} => self
+                        .build_eager_if_else_action(
+                            workflow_graph.clone(),
+                            node_states.clone(),
+                            n,
+                            loc,
+                        )
+                        .into_stream()
+                        .boxed_local(),
                 }
             })
             .boxed_local())
@@ -435,7 +438,7 @@ impl Orchestrator {
     }
 
     #[instrument(skip(self, workflow_graph, node_states), fields(loc = %loc), err)]
-    fn build_if_else_action(
+    async fn build_if_else_action(
         &self,
         workflow_graph: Arc<WorkflowGraph>,
         node_states: Arc<HashMap<NodeIndex, (NodeDefinition, NodeState)>>,
@@ -459,7 +462,8 @@ impl Orchestrator {
                         .as_ref()
                         .ok_or_else(|| miette!("`pred` node has no outputs"))?,
                     connected_port_name,
-                )?;
+                )
+                .await?;
 
                 Ok(Action {
                     loc,
@@ -507,7 +511,7 @@ impl Orchestrator {
     }
 
     #[instrument(skip(self, workflow_graph, node_states), fields(loc = %loc), err)]
-    fn build_eager_if_else_action(
+    async fn build_eager_if_else_action(
         &self,
         workflow_graph: Arc<WorkflowGraph>,
         node_states: Arc<HashMap<NodeIndex, (NodeDefinition, NodeState)>>,
@@ -516,7 +520,7 @@ impl Orchestrator {
     ) -> miette::Result<Action> {
         let mut inputs = collect_inputs(&workflow_graph, &node_states, n)?;
 
-        let pred_bytes = load_asset(&self.asset_storage_registry, &inputs, "pred")?;
+        let pred_bytes = load_asset(&self.asset_storage_registry, &inputs, "pred").await?;
         let mut outputs = HashMap::new();
 
         if pred_bytes == b"true" {
@@ -552,7 +556,7 @@ impl Orchestrator {
     }
 
     #[instrument(skip(self), fields(loc = %loc), err)]
-    fn build_const_action(
+    async fn build_const_action(
         &self,
         loc: Location,
         value: serde_json::Value,
@@ -562,7 +566,8 @@ impl Orchestrator {
             &self.asset_storage_registry,
             &self.default_storage_name,
             value_bytes,
-        )?;
+        )
+        .await?;
 
         let mut outputs = HashMap::new();
         outputs.insert("value".to_string(), asset_key);
@@ -612,7 +617,7 @@ impl Orchestrator {
         let inputs = collect_inputs(&workflow_graph, &node_states, n)?;
 
         let subgraph = if inputs.contains_key("graph") {
-            self.load_subgraph(&inputs)?
+            self.load_subgraph(&inputs).await?
         } else {
             workflow_graph
         };
@@ -667,7 +672,7 @@ impl Orchestrator {
                 // TODO: We probably don't need the inputs if we have already
                 // visited this loop iteration.
                 let mut inputs = collect_inputs(&workflow_graph, &node_states, n)?;
-                let subgraph = self.load_subgraph(&inputs)?;
+                let subgraph = self.load_subgraph(&inputs).await?;
 
                 let loop_loc = loc.with_loop_index(index);
                 let loop_subgraph_output_loc = loop_loc.with_node(subgraph.output_idx());
@@ -702,7 +707,8 @@ impl Orchestrator {
                     }
                     Some(outputs) => {
                         let should_continue_bytes =
-                            load_asset(&self.asset_storage_registry, &outputs, "should_continue")?;
+                            load_asset(&self.asset_storage_registry, &outputs, "should_continue")
+                                .await?;
 
                         if should_continue_bytes == b"true" {
                             Ok(stream::once(future::ok(Action {
@@ -736,7 +742,7 @@ impl Orchestrator {
         completed: Option<BitVec<u8>>,
     ) -> miette::Result<LocalBoxStream<'a, miette::Result<Action>>> {
         let inputs = collect_inputs(&workflow_graph, &node_states, n)?;
-        let subgraph = self.load_subgraph(&inputs)?;
+        let subgraph = self.load_subgraph(&inputs).await?;
 
         Ok(match completed {
             None => {
@@ -759,7 +765,7 @@ impl Orchestrator {
                     subgraph.output_idx(),
                 )
                 .into_stream()
-                .boxed(),
+                .boxed_local(),
             Some(completed) => {
                 self.build_subsequent_map_actions(
                     workflow_run_state,
@@ -785,7 +791,7 @@ impl Orchestrator {
         let mut input_sets = Vec::new();
         for mapped_port in mapped_ports {
             let unfolded_assets =
-                unfold_asset(&self.asset_storage_registry, &inputs, &mapped_port)?;
+                unfold_asset(&self.asset_storage_registry, &inputs, &mapped_port).await?;
 
             if input_sets.is_empty() {
                 input_sets.extend(iter::repeat_n(inputs.clone(), unfolded_assets.len()));
@@ -884,7 +890,7 @@ impl Orchestrator {
         map_size: usize,
         output_idx: NodeIndex,
     ) -> miette::Result<Action> {
-        let mut assets: HashMap<String, Vec<_>> = workflow_graph
+        let mut asset_bundles: HashMap<String, Vec<_>> = workflow_graph
             .output_names(n)?
             .map(|name| (name.clone(), Vec::new()))
             .collect();
@@ -899,20 +905,21 @@ impl Orchestrator {
                 .ok_or_else(|| miette!("No outputs!"))?;
 
             for (k, v) in outputs {
-                let entry = assets.entry(k).or_default();
+                let entry = asset_bundles.entry(k).or_default();
                 entry.push(v);
             }
         }
 
-        let outputs = assets
-            .into_iter()
-            .map(|(k, v)| {
-                let asset_spec =
-                    fold_assets(&self.asset_storage_registry, &self.default_storage_name, v)?;
-
-                Ok((k, asset_spec))
-            })
-            .collect::<miette::Result<_>>()?;
+        let mut outputs = HashMap::new();
+        for (name, asset_specs) in asset_bundles {
+            let folded_asset_spec = fold_assets(
+                &self.asset_storage_registry,
+                &self.default_storage_name,
+                asset_specs,
+            )
+            .await?;
+            outputs.insert(name, folded_asset_spec);
+        }
 
         Ok(Action {
             loc,
@@ -921,11 +928,11 @@ impl Orchestrator {
     }
 
     #[instrument(skip(self, inputs), err)]
-    fn load_subgraph(
+    async fn load_subgraph(
         &self,
         inputs: &HashMap<String, AssetSpec>,
     ) -> miette::Result<Arc<WorkflowGraph>> {
-        let subgraph_bytes = load_asset(&self.asset_storage_registry, inputs, "graph")?;
+        let subgraph_bytes = load_asset(&self.asset_storage_registry, inputs, "graph").await?;
         let subgraph_res: Result<WorkflowGraph, serde_json::Error> =
             serde_json::from_slice(&subgraph_bytes);
 
@@ -1168,16 +1175,26 @@ mod tests {
 
     use super::*;
 
-    fn test_executor_registry(asset_storage_registry: &AssetStorageRegistry) -> ExecutorRegistry {
+    async fn test_executor_registry(
+        asset_storage_registry: &AssetStorageRegistry,
+    ) -> ExecutorRegistry {
         let mut executor_registry: HashMap<String, Box<dyn Executor>> = HashMap::new();
 
         executor_registry.insert(
             "memory".to_string(),
-            Box::new(InMemoryExecutor::try_new(asset_storage_registry, "memory").unwrap()),
+            Box::new(
+                InMemoryExecutor::try_new(asset_storage_registry, "memory")
+                    .await
+                    .unwrap(),
+            ),
         );
         executor_registry.insert(
             "subprocess".to_string(),
-            Box::new(SubprocessExecutor::try_new(asset_storage_registry, "file", "file").unwrap()),
+            Box::new(
+                SubprocessExecutor::try_new(asset_storage_registry, "file", "file")
+                    .await
+                    .unwrap(),
+            ),
         );
 
         Arc::new(executor_registry)
@@ -1386,14 +1403,15 @@ mod tests {
         two_inputs_two_outputs: WorkflowGraph,
     ) -> miette::Result<()> {
         let (registry, input_sets, _dir) =
-            test_storage_registry(vec![json!({"a": 1, "b": 4})], vec![]);
-        let executor_registry = test_executor_registry(&registry);
+            test_storage_registry(vec![json!({"a": 1, "b": 4})], vec![]).await;
+        let executor_registry = test_executor_registry(&registry).await;
         let orchestrator = Orchestrator::try_new(
             &registry,
             &executor_registry,
             default_storage_name,
             "memory",
-        )?;
+        )
+        .await?;
 
         let workflow_graph = Arc::new(two_inputs_two_outputs);
 
@@ -1420,14 +1438,16 @@ mod tests {
         #[case] default_storage_name: &str,
         one_input_one_output: WorkflowGraph,
     ) -> miette::Result<()> {
-        let (registry, input_sets, _dir) = test_storage_registry(vec![json!({"a": 1})], vec![]);
-        let executor_registry = test_executor_registry(&registry);
+        let (registry, input_sets, _dir) =
+            test_storage_registry(vec![json!({"a": 1})], vec![]).await;
+        let executor_registry = test_executor_registry(&registry).await;
         let orchestrator = Orchestrator::try_new(
             &registry,
             &executor_registry,
             default_storage_name,
             "memory",
-        )?;
+        )
+        .await?;
         let mut stream = orchestrator.listen()?;
         let workflow_graph = Arc::new(one_input_one_output);
 
@@ -1451,7 +1471,8 @@ mod tests {
             "memory", // Asset is not modified so it remains in memory.
             &input_complete_outputs[0],
             json!({"a": 1}),
-        );
+        )
+        .await;
 
         workflow_run_state.write(input_complete_event).await?;
         let actions =
@@ -1479,7 +1500,8 @@ mod tests {
             "memory", // Asset is not modified so it remains in memory.
             &output_complete_outputs[0],
             json!({"out": 1}),
-        );
+        )
+        .await;
 
         Ok(())
     }
@@ -1498,14 +1520,16 @@ mod tests {
         let (registry, input_sets, _dir) = test_storage_registry(
             vec![json!({"a": 1, "subworkflow": one_input_one_output})],
             vec![],
-        );
-        let executor_registry = test_executor_registry(&registry);
+        )
+        .await;
+        let executor_registry = test_executor_registry(&registry).await;
         let orchestrator = Orchestrator::try_new(
             &registry,
             &executor_registry,
             default_storage_name,
             "memory",
-        )?;
+        )
+        .await?;
         let mut stream = orchestrator.listen()?;
 
         let workflow_graph = Arc::new(simple_eval);
@@ -1533,13 +1557,15 @@ mod tests {
             "memory", // Asset is not modified so it remains in memory.
             &inputs_complete_outputs[0],
             json!({"subworkflow": one_input_one_output}),
-        );
+        )
+        .await;
         assert_registry_contains_values(
             &registry,
             "memory", // Asset is not modified so it remains in memory.
             &inputs_complete_outputs[1],
             json!({"a": 1}),
-        );
+        )
+        .await;
 
         workflow_run_state.write(inputs_complete_event).await?;
 
@@ -1560,7 +1586,8 @@ mod tests {
             "memory", // Asset is not modified so it remains in memory.
             &inner_inputs_complete_outputs[0],
             json!({"a": 1}),
-        );
+        )
+        .await;
 
         workflow_run_state
             .write(inner_inputs_complete_event)
@@ -1578,7 +1605,8 @@ mod tests {
             "memory", // Asset is not modified so it remains in memory.
             &inner_output_complete_outputs[0],
             json!({"out": 1}),
-        );
+        )
+        .await;
 
         let eval_complete_event = Event::Node(NodeEvent {
             locs: vec![Location::new("N3")?],
@@ -1603,7 +1631,8 @@ mod tests {
             "memory", // Asset is not modified so it remains in memory.
             &output_complete_outputs[0],
             json!({"out": 1}),
-        );
+        )
+        .await;
 
         Ok(())
     }
@@ -1620,14 +1649,16 @@ mod tests {
     ) -> miette::Result<()> {
         let workflow_graph = Arc::new(simple_task);
 
-        let (registry, input_sets, _dir) = test_storage_registry(vec![json!({"a": 1})], vec![]);
-        let executor_registry = test_executor_registry(&registry);
+        let (registry, input_sets, _dir) =
+            test_storage_registry(vec![json!({"a": 1})], vec![]).await;
+        let executor_registry = test_executor_registry(&registry).await;
         let orchestrator = Orchestrator::try_new(
             &registry,
             &executor_registry,
             default_storage_name,
             "memory",
-        )?;
+        )
+        .await?;
 
         let (workflow_run_state, mut state_recv) = InMemoryWorkflowRunState::test();
         let workflow_run_state = Arc::new(workflow_run_state);
@@ -1690,7 +1721,8 @@ mod tests {
             default_storage_name,
             &outputs,
             json!({"out": 4}),
-        );
+        )
+        .await;
 
         Ok(())
     }
@@ -1711,14 +1743,16 @@ mod tests {
         let (registry, input_sets, _dir) = test_storage_registry(
             vec![json!({"a": 1, "subworkflow": one_input_one_output})],
             vec![],
-        );
-        let executor_registry = test_executor_registry(&registry);
+        )
+        .await;
+        let executor_registry = test_executor_registry(&registry).await;
         let orchestrator = Orchestrator::try_new(
             &registry,
             &executor_registry,
             default_storage_name,
             "memory",
-        )?;
+        )
+        .await?;
 
         let (workflow_run_state, mut state_recv) = InMemoryWorkflowRunState::test();
         let workflow_run_state = Arc::new(workflow_run_state);
@@ -1785,7 +1819,8 @@ mod tests {
             "memory", // Asset is not modified so it remains in memory.
             &outputs,
             json!({"out": 1}),
-        );
+        )
+        .await;
 
         Ok(())
     }
@@ -1813,14 +1848,15 @@ mod tests {
         let default_storage_name = "memory";
         let workflow_graph = Arc::new(workflow_graph);
 
-        let (registry, input_sets, _dir) = test_storage_registry(vec![inputs], vec![]);
-        let executor_registry = test_executor_registry(&registry);
+        let (registry, input_sets, _dir) = test_storage_registry(vec![inputs], vec![]).await;
+        let executor_registry = test_executor_registry(&registry).await;
         let orchestrator = Orchestrator::try_new(
             &registry,
             &executor_registry,
             default_storage_name,
             "memory",
-        )?;
+        )
+        .await?;
 
         let (workflow_run_state, mut state_recv) = InMemoryWorkflowRunState::test();
         let workflow_run_state = Arc::new(workflow_run_state);
@@ -1865,7 +1901,8 @@ mod tests {
             &orchestrator.default_storage_name,
             &outputs,
             expected_outputs,
-        );
+        )
+        .await;
 
         Ok(())
     }
@@ -1881,14 +1918,15 @@ mod tests {
             serde_json::from_str(serialized_graph).into_diagnostic()?;
         let workflow_graph = Arc::new(graph.to_workflow_graph().unwrap());
 
-        let (registry, _input_sets, _dir) = test_storage_registry(vec![], vec![]);
-        let executor_registry = test_executor_registry(&registry);
+        let (registry, _input_sets, _dir) = test_storage_registry(vec![], vec![]).await;
+        let executor_registry = test_executor_registry(&registry).await;
         let orchestrator = Orchestrator::try_new(
             &registry,
             &executor_registry,
             default_storage_name,
             "memory",
-        )?;
+        )
+        .await?;
 
         let (workflow_run_state, mut state_recv) = InMemoryWorkflowRunState::test();
         let workflow_run_state = Arc::new(workflow_run_state);
@@ -1932,7 +1970,8 @@ mod tests {
             &orchestrator.default_storage_name,
             &outputs,
             json!({"simple_eval_output": 12}),
-        );
+        )
+        .await;
 
         Ok(())
     }

--- a/tierkreis/src/runtime.rs
+++ b/tierkreis/src/runtime.rs
@@ -1,14 +1,10 @@
 /*!
 The runtime module defines the entrypoint to running Workflows.
 */
-use std::{
-    collections::HashMap,
-    hash::BuildHasher,
-    path::Path,
-    sync::{Arc, RwLock},
-};
+use std::{collections::HashMap, hash::BuildHasher, path::Path, sync::Arc};
 
 use miette::{IntoDiagnostic, miette};
+use tokio::sync::RwLock;
 use uuid::Uuid;
 
 use crate::{
@@ -47,18 +43,11 @@ impl Runtime<SqliteRuntimeState> {
         let mut executor_registry: HashMap<String, Box<dyn Executor>> = HashMap::new();
         executor_registry.insert(
             "memory".to_string(),
-            Box::new(InMemoryExecutor::try_new(
-                &asset_storage_registry,
-                "memory",
-            )?),
+            Box::new(InMemoryExecutor::try_new(&asset_storage_registry, "memory").await?),
         );
         executor_registry.insert(
             "subprocess".to_string(),
-            Box::new(SubprocessExecutor::try_new(
-                &asset_storage_registry,
-                "file",
-                "file",
-            )?),
+            Box::new(SubprocessExecutor::try_new(&asset_storage_registry, "file", "file").await?),
         );
         let executor_registry = Arc::new(executor_registry);
 
@@ -67,7 +56,8 @@ impl Runtime<SqliteRuntimeState> {
             &executor_registry,
             "file",
             "subprocess",
-        )?;
+        )
+        .await?;
 
         let runtime_state = SqliteRuntimeState::try_new().await?;
 
@@ -93,10 +83,7 @@ impl Runtime<SqliteRuntimeState> {
 
         executor_registry.insert(
             "memory".to_string(),
-            Box::new(InMemoryExecutor::try_new(
-                &asset_storage_registry,
-                "memory",
-            )?),
+            Box::new(InMemoryExecutor::try_new(&asset_storage_registry, "memory").await?),
         );
         let executor_registry = Arc::new(executor_registry);
 
@@ -105,7 +92,8 @@ impl Runtime<SqliteRuntimeState> {
             &executor_registry,
             "memory",
             "memory",
-        )?;
+        )
+        .await?;
 
         let runtime_state = SqliteRuntimeState::try_new_in_memory().await?;
 
@@ -122,7 +110,7 @@ impl Runtime<SqliteRuntimeState> {
 impl Runtime<InMemoryRuntimeState> {
     // TODO: Add a from_config function to build a Runtime from a configuration file.
     #[allow(dead_code)]
-    fn memory() -> miette::Result<Self> {
+    async fn memory() -> miette::Result<Self> {
         let mut asset_storage_registry: HashMap<String, Box<dyn AssetStorage>> = HashMap::new();
         let memory_storage = InMemoryStorage::new();
         asset_storage_registry.insert("memory".to_string(), Box::new(memory_storage));
@@ -133,10 +121,7 @@ impl Runtime<InMemoryRuntimeState> {
 
         executor_registry.insert(
             "memory".to_string(),
-            Box::new(InMemoryExecutor::try_new(
-                &asset_storage_registry,
-                "memory",
-            )?),
+            Box::new(InMemoryExecutor::try_new(&asset_storage_registry, "memory").await?),
         );
         let executor_registry = Arc::new(executor_registry);
 
@@ -145,7 +130,8 @@ impl Runtime<InMemoryRuntimeState> {
             &executor_registry,
             "memory",
             "memory",
-        )?;
+        )
+        .await?;
 
         let runtime_state = InMemoryRuntimeState::new();
 
@@ -201,7 +187,7 @@ impl<RS: RuntimeState> Runtime<RS> {
             }
         });
 
-        let inputs = save_assets(&self.asset_storage_registry, "memory", inputs)?;
+        let inputs = save_assets(&self.asset_storage_registry, "memory", inputs).await?;
         self.inputs.clone_from(&inputs);
         // TODO: Maybe inputs should be part of the workflow run state?
         let context = OrchestrationContext::new(&workflow_run_state, inputs);
@@ -270,7 +256,8 @@ impl<RS: RuntimeState> Runtime<RS> {
             &output_state
                 .outputs
                 .ok_or_else(|| miette!("No output values on Output node."))?,
-        )?;
+        )
+        .await?;
 
         Ok(outputs)
     }


### PR DESCRIPTION
Change the methods on the AssetStorage interface to be async and start using the tokio fs implementation. This has some minimal overhead for assets stored in memory but should help with future io based assets including s3 storage etc.